### PR TITLE
Fix centralized ingress templates: SG, ALB to NLB, IAM, UserData

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,6 +41,7 @@ Routes inbound internet traffic through a dedicated Edge VPC containing Network 
 | [Single AZ Ingress](centralized_architecture/centralized_ingress_single_az/) | Single availability zone (NLB with TLS termination) |
 | [Two AZ Ingress](centralized_architecture/centralized_ingress_two_az/) | High availability across two AZs (ALB with HTTPS termination) |
 
+<!-- TODO: Add architecture diagram for centralized ingress inspection (current image shows egress/east-west only) -->
 ![Centralized Architecture](images/anfw-centralized-model-1az.png)
 
 ### Distributed Architecture

--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ Routes inbound internet traffic through a dedicated Edge VPC containing Network 
 | Template | Use Case |
 |----------|----------|
 | [Single AZ Ingress](centralized_architecture/centralized_ingress_single_az/) | Single availability zone (NLB with TLS termination) |
-| [Two AZ Ingress](centralized_architecture/centralized_ingress_two_az/) | High availability across two AZs (ALB with HTTPS termination) |
+| [| [Two AZ Ingress](centralized_architecture/centralized_ingress_two_az/) | High availability across two AZs (NLB with TLS termination) |
 
 <!-- TODO: Add architecture diagram for centralized ingress inspection (current image shows egress/east-west only) -->
 ![Centralized Architecture](images/anfw-centralized-model-1az.png)

--- a/README.md
+++ b/README.md
@@ -32,6 +32,15 @@ Routes traffic through a dedicated inspection VPC containing the firewall endpoi
 | [Single AZ](centralized_architecture/single_az_deployment/) | Single availability zone |
 | [Two AZ](centralized_architecture/two_az_deployment/) | High availability across two AZs |
 
+#### [Centralized Ingress Inspection](centralized_architecture/)
+
+Routes inbound internet traffic through a dedicated Edge VPC containing Network Firewall endpoints for inspection before forwarding to spoke VPCs via Transit Gateway. TLS is terminated at the Edge load balancer.
+
+| Template | Use Case |
+|----------|----------|
+| [Single AZ Ingress](centralized_architecture/centralized_ingress_single_az/) | Single availability zone (NLB with TLS termination) |
+| [Two AZ Ingress](centralized_architecture/centralized_ingress_two_az/) | High availability across two AZs (ALB with HTTPS termination) |
+
 ![Centralized Architecture](images/anfw-centralized-model-1az.png)
 
 ### Distributed Architecture

--- a/centralized_architecture/README.md
+++ b/centralized_architecture/README.md
@@ -27,6 +27,20 @@ Both templates create:
 
 **Spoke VPCs** - Example workload VPCs that route traffic through the inspection VPC
 
+### Centralized Ingress Inspection
+
+Templates that add ingress traffic inspection to the centralized model. All inbound internet traffic is routed through AWS Network Firewall in an Edge VPC before reaching spoke VPC workloads via Transit Gateway. TLS is terminated at the Edge load balancer; downstream traffic to spoke NLBs and EC2 instances uses plaintext HTTP.
+
+#### [Single AZ Ingress Deployment](centralized_ingress_single_az/)
+- **Template:** `anfw-centralized-ingress-1az-template.yaml`
+- **Use Case:** Testing and proof-of-concept environments
+- **Edge LB:** Internet-facing NLB with TLS termination (ALBs require 2 AZs)
+
+#### [Two AZ Ingress Deployment](centralized_ingress_two_az/)
+- **Template:** `anfw-centralized-ingress-2az-template.yaml`
+- **Use Case:** Production environments requiring high availability
+- **Edge LB:** Internet-facing ALB with HTTPS termination across two AZs
+
 
 ## Additional Resources
 

--- a/centralized_architecture/README.md
+++ b/centralized_architecture/README.md
@@ -24,12 +24,12 @@ Templates that add ingress traffic inspection to the centralized model. All inbo
 #### [Single AZ Ingress Deployment](centralized_ingress_single_az/)
 - **Template:** `anfw-centralized-ingress-1az-template.yaml`
 - **Use Case:** Testing and proof-of-concept environments
-- **Edge LB:** Internet-facing NLB with TLS termination (ALBs require 2 AZs)
+- **- **Edge LB:** Internet-facing NLB with TLS termination across two AZs
 
 #### [Two AZ Ingress Deployment](centralized_ingress_two_az/)
 - **Template:** `anfw-centralized-ingress-2az-template.yaml`
 - **Use Case:** Production environments requiring high availability
-- **Edge LB:** Internet-facing ALB with HTTPS termination across two AZs
+- **Edge LB:** Internet-facing NLB with TLS termination across two AZs
 
 
 ## Architecture Components

--- a/centralized_architecture/README.md
+++ b/centralized_architecture/README.md
@@ -16,18 +16,8 @@ This folder contains two CloudFormation templates that deploy the same centraliz
 - **Use Case:** Production environments requiring high availability
 - **Resources:** Components distributed across two Availability Zones
 
-## Architecture Components
 
-Both templates create:
-
-**Inspection VPC** - Centralized VPC for both East-West and Egress traffic inspection
-- Transit Gateway subnet
-- Firewall subnet (contains AWS Network Firewall endpoints)
-- Public subnet (contains NAT Gateway(s) for Internet access)
-
-**Spoke VPCs** - Example workload VPCs that route traffic through the inspection VPC
-
-### Centralized Ingress Inspection
+## Ingress-only Inspection
 
 Templates that add ingress traffic inspection to the centralized model. All inbound internet traffic is routed through AWS Network Firewall in an Edge VPC before reaching spoke VPC workloads via Transit Gateway. TLS is terminated at the Edge load balancer; downstream traffic to spoke NLBs and EC2 instances uses plaintext HTTP.
 
@@ -40,6 +30,18 @@ Templates that add ingress traffic inspection to the centralized model. All inbo
 - **Template:** `anfw-centralized-ingress-2az-template.yaml`
 - **Use Case:** Production environments requiring high availability
 - **Edge LB:** Internet-facing ALB with HTTPS termination across two AZs
+
+
+## Architecture Components
+
+Both templates create:
+
+**Inspection VPC** - Centralized VPC for both East-West and Egress traffic inspection
+- Transit Gateway subnet
+- Firewall subnet (contains AWS Network Firewall endpoints)
+- Public subnet (contains NAT Gateway(s) for Internet access)
+
+**Spoke VPCs** - Example workload VPCs that route traffic through the inspection VPC
 
 
 ## Additional Resources

--- a/centralized_architecture/centralized_ingress_single_az/README.md
+++ b/centralized_architecture/centralized_ingress_single_az/README.md
@@ -1,0 +1,126 @@
+# Centralized Ingress Inspection - Single AZ Deployment
+
+**Template File:** [anfw-centralized-ingress-1az-template.yaml](anfw-centralized-ingress-1az-template.yaml)
+
+This template deploys AWS Network Firewall in a centralized ingress inspection architecture within a single Availability Zone. All inbound internet traffic is routed through the Network Firewall in an Edge VPC before reaching application workloads in spoke VPCs via Transit Gateway. This configuration is designed for testing, development, and proof-of-concept environments.
+
+## Architecture Overview
+
+This single AZ deployment creates a centralized ingress inspection model using an Edge VPC with an internet-facing Network Load Balancer, AWS Network Firewall, and AWS Transit Gateway. Inbound traffic from the internet enters through the Edge VPC Internet Gateway, is steered through the Network Firewall for inspection via an IGW Ingress Route Table, and then reaches the Edge NLB. The Edge NLB forwards traffic to spoke VPC NLBs via Transit Gateway, which in turn distribute traffic to EC2 instances running httpd.
+
+The Edge VPC uses an NLB (not an ALB) because ALBs require a minimum of two Availability Zones. For the high-availability variant with ALB support, see the [Two AZ Deployment](../centralized_ingress_two_az/).
+
+## Resources Created
+
+### Edge VPC (100.64.0.0/16)
+Centralized VPC for ingress traffic inspection:
+- **Firewall Subnet** (100.64.0.16/28) - Contains the AWS Network Firewall endpoint
+- **Public Subnet** (100.64.1.0/24) - Contains the internet-facing NLB and NAT Gateway
+- **TGW Subnet** (100.64.0.0/28) - Attachment point for Transit Gateway
+- **Internet Gateway** - Entry point for inbound internet traffic
+- **NAT Gateway** - Provides outbound internet access for spoke EC2 instances (package installation, SSM)
+
+### AWS Network Firewall
+- Firewall endpoint deployed in the Edge VPC Firewall Subnet
+- Firewall policy with STRICT_ORDER rule ordering and REJECT stream exception
+- Log-only Suricata rule group for ingress traffic (alerts on HTTP, HTTPS, SSH, ICMP)
+- Comprehensive allow-list rule group (defined but not referenced in policy by default)
+- CloudWatch logging for both ALERT and FLOW log types (30-day retention)
+
+### Spoke VPCs
+Two example workload VPCs demonstrating end-to-end ingress traffic flow:
+- **Spoke A** (10.1.0.0/16) - Workload subnet, TGW subnet, EC2 instance with httpd (port 80)
+- **Spoke B** (10.2.0.0/16) - Workload subnet, TGW subnet, EC2 instance with httpd (port 80)
+- Internal NLBs with static private IPs fronting EC2 instances in each spoke (TCP port 80 only)
+- SSM VPC endpoints for instance management
+- Security groups allowing ICMP and HTTP from required CIDRs
+
+### Edge NLB
+- Internet-facing Network Load Balancer in the Edge VPC Public Subnet
+- TLS listener on port 443 that terminates TLS using an ACM certificate and forwards to port 80
+- TCP listener on port 80
+- Single IP-type target group (port 80) with spoke NLB static IPs pre-registered
+
+### Transit Gateway
+- Central routing hub connecting Edge VPC and spoke VPCs
+- Spoke route table with default route to Edge VPC attachment
+- Inspection route table with propagated spoke routes
+- Appliance Mode enabled on the Edge VPC attachment for flow symmetry
+
+## Traffic Flow
+
+### Ingress Path (Internet → Application)
+1. Client request arrives at the Internet Gateway
+2. IGW Ingress Route Table steers traffic to the Network Firewall endpoint (Public Subnet CIDR → Firewall Endpoint)
+3. Network Firewall inspects the inbound traffic using Suricata stateful rules
+4. Inspected traffic reaches the Edge NLB in the Public Subnet via VPC local route
+5. Edge NLB forwards to spoke NLB IPs via Transit Gateway (Public Subnet routes 10.0.0.0/8 → TGW)
+6. Spoke NLB distributes traffic to EC2 instances running httpd
+
+### Ingress Return Path (Application → Internet) — Symmetric
+1. EC2 response returns through the spoke NLB → Transit Gateway → Edge NLB
+2. Edge NLB sends the response to the client; Public Subnet routes 0.0.0.0/0 → **Firewall Endpoint**
+3. Network Firewall inspects the return traffic (matching the stateful flow from the inbound path)
+4. Firewall Subnet routes 0.0.0.0/0 → **Internet Gateway**; response exits to the internet
+
+> **Symmetric routing**: Inbound traffic goes IGW → Firewall → NLB, and return traffic goes NLB → Firewall → IGW. The firewall sees both directions of every flow.
+
+### Spoke Egress Path (e.g., yum install, SSM)
+1. Spoke EC2 initiates outbound connection → Spoke route table sends 0.0.0.0/0 → TGW
+2. TGW Subnet route table sends 0.0.0.0/0 → **NAT Gateway** (source IP translated)
+3. NAT Gateway outbound follows Public Subnet route: 0.0.0.0/0 → **Firewall Endpoint**
+4. Firewall inspects the NAT'd egress traffic → Firewall Subnet routes 0.0.0.0/0 → **IGW**
+5. Return traffic from the internet is steered back through the firewall via the IGW Ingress Route Table
+
+## Key Routing Design
+
+The routing differs from the existing egress/east-west templates to support symmetric ingress inspection:
+
+| Route Table | Default Route (0.0.0.0/0) | Purpose |
+|---|---|---|
+| IGW Ingress RT | Public Subnet CIDR → Firewall Endpoint | Steer inbound traffic through firewall |
+| Firewall Subnet RT | → Internet Gateway | Exit point for all inspected outbound traffic |
+| Public Subnet RT | → Firewall Endpoint | Ensures ALB return traffic and NAT GW egress pass through firewall |
+| TGW Subnet RT | → NAT Gateway | Spoke egress gets NAT'd before firewall inspection |
+| Spoke Workload RT | → Transit Gateway | All spoke outbound traffic via TGW |
+
+## Deployment Instructions
+
+1. Ensure you have appropriate AWS permissions
+2. Provision or import an ACM certificate for the Edge NLB TLS listener
+3. Deploy the CloudFormation template:
+   ```bash
+   aws cloudformation create-stack \
+     --stack-name anfw-centralized-ingress-1az \
+     --template-body file://anfw-centralized-ingress-1az-template.yaml \
+     --capabilities CAPABILITY_IAM \
+     --parameters ParameterKey=NLBCertificateArn,ParameterValue=arn:aws:acm:REGION:ACCOUNT:certificate/CERTIFICATE-ID
+   ```
+4. Wait for the stack to reach `CREATE_COMPLETE` status
+5. Allow approximately 8-10 minutes after stack completion for EC2 instances to finish UserData execution (installing httpd via the NAT Gateway egress path) and for the Edge NLB target group health checks to pass. You can monitor target health with:
+   ```bash
+   aws elbv2 describe-target-health \
+     --target-group-arn $(aws elbv2 describe-target-groups --names e-http-anfw-centralized-ingress-1az --query 'TargetGroups[0].TargetGroupArn' --output text)
+   ```
+6. Access the Edge NLB DNS name from the stack outputs to test ingress traffic flow
+
+## Important Notes
+
+- **Single AZ Limitation** - This deployment lacks high availability and should not be used in production. Designed for development, testing, and learning environments.
+- **NLB vs ALB** - The 1AZ template uses an internet-facing NLB because ALBs require a minimum of 2 AZs. The [Two AZ Deployment](../centralized_ingress_two_az/) uses an ALB for Layer 7 capabilities.
+- **TLS Termination** - TLS is terminated at the Edge NLB using an ACM certificate. All downstream traffic to spoke NLBs and EC2 instances is plaintext HTTP on port 80.
+- **Spoke NLB Static IPs** - Spoke NLBs use static private IPs via SubnetMappings, pre-registered as Edge NLB targets. No manual target registration is needed.
+- **Symmetric Inspection** - The Public Subnet routes 0.0.0.0/0 to the Firewall Endpoint (not the IGW) to ensure return traffic passes through the firewall, avoiding asymmetric routing.
+
+## Production Considerations
+
+For environments requiring high availability, consider the [Two AZ Deployment](../centralized_ingress_two_az/) which provides:
+- High availability across multiple Availability Zones
+- ALB with Layer 7 capabilities and HTTPS termination
+- AZ-specific routing for fault tolerance
+
+## Additional Resources
+
+- [AWS Network Firewall Documentation](https://docs.aws.amazon.com/network-firewall/)
+- [AWS Transit Gateway Documentation](https://docs.aws.amazon.com/transit-gateway/)
+- [Deployment models for AWS Network Firewall Blog](https://aws.amazon.com/blogs/networking-and-content-delivery/deployment-models-for-aws-network-firewall/)

--- a/centralized_architecture/centralized_ingress_single_az/README.md
+++ b/centralized_architecture/centralized_ingress_single_az/README.md
@@ -65,7 +65,7 @@ Two example workload VPCs demonstrating end-to-end ingress traffic flow:
 
 > **Symmetric routing**: Inbound traffic goes IGW → Firewall → NLB, and return traffic goes NLB → Firewall → IGW. The firewall sees both directions of every flow.
 
-### Spoke Egress Path (e.g., yum install, SSM)
+### Spoke Egress Path (e.g., packages install, SSM)
 1. Spoke EC2 initiates outbound connection → Spoke route table sends 0.0.0.0/0 → TGW
 2. TGW Subnet route table sends 0.0.0.0/0 → **NAT Gateway** (source IP translated)
 3. NAT Gateway outbound follows Public Subnet route: 0.0.0.0/0 → **Firewall Endpoint**
@@ -74,7 +74,7 @@ Two example workload VPCs demonstrating end-to-end ingress traffic flow:
 
 ## Key Routing Design
 
-The routing differs from the existing egress/east-west templates to support symmetric ingress inspection:
+The routing support symmetric ingress inspection:
 
 | Route Table | Default Route (0.0.0.0/0) | Purpose |
 |---|---|---|
@@ -87,7 +87,7 @@ The routing differs from the existing egress/east-west templates to support symm
 ## Deployment Instructions
 
 1. Ensure you have appropriate AWS permissions
-2. Provision or import an ACM certificate for the Edge NLB TLS listener
+2. (Optional) Provision or import an ACM certificate for the Edge NLB TLS listener - if not provided, the template will skip the TLS listener
 3. Deploy the CloudFormation template:
    ```bash
    aws cloudformation create-stack \
@@ -108,9 +108,28 @@ The routing differs from the existing egress/east-west templates to support symm
 
 - **Single AZ Limitation** - This deployment lacks high availability and should not be used in production. Designed for development, testing, and learning environments.
 - **NLB vs ALB** - The 1AZ template uses an internet-facing NLB because ALBs require a minimum of 2 AZs. The [Two AZ Deployment](../centralized_ingress_two_az/) uses an ALB for Layer 7 capabilities.
-- **TLS Termination** - TLS is terminated at the Edge NLB using an ACM certificate. All downstream traffic to spoke NLBs and EC2 instances is plaintext HTTP on port 80.
+- **(Optional) TLS Termination** - TLS is terminated at the Edge NLB using an ACM certificate. All downstream traffic to spoke NLBs and EC2 instances is plaintext HTTP on port 80.
 - **Spoke NLB Static IPs** - Spoke NLBs use static private IPs via SubnetMappings, pre-registered as Edge NLB targets. No manual target registration is needed.
 - **Symmetric Inspection** - The Public Subnet routes 0.0.0.0/0 to the Firewall Endpoint (not the IGW) to ensure return traffic passes through the firewall, avoiding asymmetric routing.
+
+## Enabling the Allow-List Rule Group
+
+By default, only the log-only rule group is active — it alerts on inbound traffic patterns without blocking anything. The template also creates a comprehensive allow-list rule group (`IngressAllowListRuleGroup`) that is defined but not referenced in the firewall policy.
+
+When you're ready to move beyond log-only mode and enforce ingress filtering:
+
+1. Open the [Network Firewall console](https://console.aws.amazon.com/vpc/home#NetworkFirewallPolicies) and select the `ingress-firewall-policy-<stack-name>` policy
+2. Under **Stateful rule group references**, click **Add rule group** and select `ingress-allow-list-<stack-name>`
+3. Set its priority to a value higher than the log-only group (e.g., 100 if log-only is at 50) so alerts fire before enforcement
+4. Save the policy — the firewall endpoints will sync within a few minutes
+
+The allow-list rules will:
+- **Pass** inbound HTTP (port 80) and HTTPS (port 443) to HOME_NET
+- **Pass** established return traffic from HOME_NET
+- **Alert** on traffic from RU/CN geolocations
+- **Drop** all other inbound TCP, UDP, ICMP, and IP traffic
+
+> **Note:** The log-only group fires first (lower priority number), so you retain full alert visibility even after enabling enforcement. To revert to log-only mode, remove the allow-list reference from the policy. If you added the allow-list via the console (outside CloudFormation), remember to remove it before deleting the stack to avoid delete failures.
 
 ## Production Considerations
 

--- a/centralized_architecture/centralized_ingress_single_az/anfw-centralized-ingress-1az-template.yaml
+++ b/centralized_architecture/centralized_ingress_single_az/anfw-centralized-ingress-1az-template.yaml
@@ -17,6 +17,7 @@ Metadata:
           default: "VPC Parameters"
         Parameters:
           - AvailabilityZoneSelection
+          - NLBCertificateArn
       - Label:
           default: "EC2 Parameters"
         Parameters:
@@ -27,10 +28,18 @@ Parameters:
     Type: AWS::EC2::AvailabilityZone::Name
     Default: us-east-1a
 
+  NLBCertificateArn:
+    Description: ACM Certificate ARN for the Edge NLB TLS listener (leave empty to skip TLS listener)
+    Type: String
+    Default: ""
+
   LatestAmiId:
     Description: Latest EC2 AMI from Systems Manager Parameter Store
     Type: 'AWS::SSM::Parameter::Value<AWS::EC2::Image::Id>'
     Default: '/aws/service/ami-amazon-linux-latest/amzn2-ami-hvm-x86_64-gp2'
+
+Conditions:
+  HasNLBCertificate: !Not [!Equals [!Ref NLBCertificateArn, ""]]
 
 Resources:
 # Spoke VPC A
@@ -145,7 +154,7 @@ Resources:
   SubnetASecGroup:
     Type: AWS::EC2::SecurityGroup
     Properties:
-      GroupDescription: "ICMP acess from 10.0.0.0/8 and inspection VPC, HTTP/HTTPS from inspection VPC and spoke VPC"
+      GroupDescription: "ICMP acess from 10.0.0.0/8 and inspection VPC, HTTP from inspection VPC and spoke VPC"
       GroupName: !Sub "spoke-a-sec-group-${AWS::StackName}"
       VpcId: !Ref SpokeVPCA
       SecurityGroupIngress:
@@ -165,20 +174,10 @@ Resources:
           FromPort: 80
           ToPort: 80
         - IpProtocol: tcp
-          CidrIp: 100.64.0.0/16
-          Description: "Allow HTTPS from Edge VPC (NLB traffic)"
-          FromPort: 443
-          ToPort: 443
-        - IpProtocol: tcp
           CidrIp: 10.1.0.0/16
           Description: "Allow HTTP from Spoke A VPC (NLB health checks)"
           FromPort: 80
           ToPort: 80
-        - IpProtocol: tcp
-          CidrIp: 10.1.0.0/16
-          Description: "Allow HTTPS from Spoke A VPC (NLB health checks)"
-          FromPort: 443
-          ToPort: 443
 
   EC2SubnetA:
     Type: 'AWS::EC2::Instance'
@@ -198,13 +197,7 @@ Resources:
           #!/bin/bash
           # Wait for internet connectivity (egress path via NAT GW may take time to converge)
           for i in $(seq 1 30); do curl -s --max-time 5 https://amazonlinux-2-repos-us-east-1.s3.dualstack.us-east-1.amazonaws.com && break || sleep 10; done
-          yum install -y httpd mod_ssl
-          openssl req -x509 -nodes -days 365 -newkey rsa:2048 \
-            -keyout /etc/pki/tls/private/localhost.key \
-            -out /etc/pki/tls/certs/localhost.crt \
-            -subj "/CN=localhost"
-          # Harden TLS: disable weak protocols and ciphers
-          printf '%s\n' 'SSLProtocol -all +TLSv1.2' 'SSLCipherSuite ECDHE-ECDSA-AES128-GCM-SHA256:ECDHE-RSA-AES128-GCM-SHA256:ECDHE-ECDSA-AES256-GCM-SHA384:ECDHE-RSA-AES256-GCM-SHA384' 'SSLHonorCipherOrder on' > /etc/httpd/conf.d/ssl-hardening.conf
+          yum install -y httpd
           systemctl start httpd
           systemctl enable httpd
           echo "<html><body><h1>Spoke A - ${AvailabilityZoneSelection}</h1></body></html>" > /var/www/html/index.html
@@ -324,7 +317,7 @@ Resources:
   SubnetBSecGroup:
     Type: AWS::EC2::SecurityGroup
     Properties:
-      GroupDescription: "ICMP acess from 10.0.0.0/8 and inspection VPC, HTTP/HTTPS from inspection VPC and spoke VPC"
+      GroupDescription: "ICMP acess from 10.0.0.0/8 and inspection VPC, HTTP from inspection VPC and spoke VPC"
       GroupName: !Sub "spoke-b-sec-group-${AWS::StackName}"
       VpcId: !Ref SpokeVPCB
       SecurityGroupIngress:
@@ -344,20 +337,10 @@ Resources:
           FromPort: 80
           ToPort: 80
         - IpProtocol: tcp
-          CidrIp: 100.64.0.0/16
-          Description: "Allow HTTPS from Edge VPC (NLB traffic)"
-          FromPort: 443
-          ToPort: 443
-        - IpProtocol: tcp
           CidrIp: 10.2.0.0/16
           Description: "Allow HTTP from Spoke B VPC (NLB health checks)"
           FromPort: 80
           ToPort: 80
-        - IpProtocol: tcp
-          CidrIp: 10.2.0.0/16
-          Description: "Allow HTTPS from Spoke B VPC (NLB health checks)"
-          FromPort: 443
-          ToPort: 443
 
   EC2SubnetB:
     Type: 'AWS::EC2::Instance'
@@ -376,12 +359,7 @@ Resources:
         Fn::Base64: !Sub |
           #!/bin/bash
           for i in $(seq 1 30); do curl -s --max-time 5 https://amazonlinux-2-repos-us-east-1.s3.dualstack.us-east-1.amazonaws.com && break || sleep 10; done
-          yum install -y httpd mod_ssl
-          openssl req -x509 -nodes -days 365 -newkey rsa:2048 \
-            -keyout /etc/pki/tls/private/localhost.key \
-            -out /etc/pki/tls/certs/localhost.crt \
-            -subj "/CN=localhost"
-          printf '%s\n' 'SSLProtocol -all +TLSv1.2' 'SSLCipherSuite ECDHE-ECDSA-AES128-GCM-SHA256:ECDHE-RSA-AES128-GCM-SHA256:ECDHE-ECDSA-AES256-GCM-SHA384:ECDHE-RSA-AES256-GCM-SHA384' 'SSLHonorCipherOrder on' > /etc/httpd/conf.d/ssl-hardening.conf
+          yum install -y httpd
           systemctl start httpd
           systemctl enable httpd
           echo "<html><body><h1>Spoke B - ${AvailabilityZoneSelection}</h1></body></html>" > /var/www/html/index.html
@@ -428,30 +406,6 @@ Resources:
         - Type: forward
           TargetGroupArn: !Ref SpokeANLBTargetGroupHTTP
 
-  SpokeANLBTargetGroupHTTPS:
-    Type: AWS::ElasticLoadBalancingV2::TargetGroup
-    Properties:
-      Name: !Sub "sa-htps-${AWS::StackName}"
-      Port: 443
-      Protocol: TCP
-      TargetType: instance
-      VpcId: !Ref SpokeVPCA
-      Targets:
-        - Id: !Ref EC2SubnetA
-      Tags:
-        - Key: Name
-          Value: !Sub "spoke-a-nlb-tg-https-${AWS::StackName}"
-
-  SpokeANLBListenerHTTPS:
-    Type: AWS::ElasticLoadBalancingV2::Listener
-    Properties:
-      LoadBalancerArn: !Ref SpokeANLB
-      Port: 443
-      Protocol: TCP
-      DefaultActions:
-        - Type: forward
-          TargetGroupArn: !Ref SpokeANLBTargetGroupHTTPS
-
   SpokeBNLB:
     Type: AWS::ElasticLoadBalancingV2::LoadBalancer
     Properties:
@@ -488,30 +442,6 @@ Resources:
       DefaultActions:
         - Type: forward
           TargetGroupArn: !Ref SpokeBNLBTargetGroupHTTP
-
-  SpokeBNLBTargetGroupHTTPS:
-    Type: AWS::ElasticLoadBalancingV2::TargetGroup
-    Properties:
-      Name: !Sub "sb-htps-${AWS::StackName}"
-      Port: 443
-      Protocol: TCP
-      TargetType: instance
-      VpcId: !Ref SpokeVPCB
-      Targets:
-        - Id: !Ref EC2SubnetB
-      Tags:
-        - Key: Name
-          Value: !Sub "spoke-b-nlb-tg-https-${AWS::StackName}"
-
-  SpokeBNLBListenerHTTPS:
-    Type: AWS::ElasticLoadBalancingV2::Listener
-    Properties:
-      LoadBalancerArn: !Ref SpokeBNLB
-      Port: 443
-      Protocol: TCP
-      DefaultActions:
-        - Type: forward
-          TargetGroupArn: !Ref SpokeBNLBTargetGroupHTTPS
 
 # Edge VPC - Central VPC hosting IGW, Network Firewall, ALB, and NAT Gateway
 # All inbound internet traffic enters through this VPC and is inspected by the firewall before reaching spoke workloads
@@ -615,7 +545,8 @@ Resources:
         - Key: Name
           Value: !Sub "edge-nlb-${AWS::StackName}"
 
-  # IP-type target groups targeting spoke NLB static IPs via TGW
+  # IP-type target group targeting spoke NLB static IPs via TGW (port 80 only)
+  # TLS is terminated at the Edge NLB; all downstream traffic is plaintext HTTP
   # Spoke A NLB: 10.1.1.10, Spoke B NLB: 10.2.1.10 (assigned via SubnetMappings PrivateIPv4Address)
   # AvailabilityZone: "all" is required for cross-VPC IP targets routed via TGW
   EdgeNLBTargetGroupHTTP:
@@ -635,23 +566,6 @@ Resources:
         - Key: Name
           Value: !Sub "e-tg-http-${AWS::StackName}"
 
-  EdgeNLBTargetGroupHTTPS:
-    Type: AWS::ElasticLoadBalancingV2::TargetGroup
-    Properties:
-      Name: !Sub "e-htps-${AWS::StackName}"
-      Port: 443
-      Protocol: TCP
-      TargetType: ip
-      VpcId: !Ref EdgeVPC
-      Targets:
-        - Id: "10.1.1.10"
-          AvailabilityZone: "all"
-        - Id: "10.2.1.10"
-          AvailabilityZone: "all"
-      Tags:
-        - Key: Name
-          Value: !Sub "e-tg-https-${AWS::StackName}"
-
   EdgeNLBListenerHTTP:
     Type: AWS::ElasticLoadBalancingV2::Listener
     Properties:
@@ -662,15 +576,20 @@ Resources:
         - Type: forward
           TargetGroupArn: !Ref EdgeNLBTargetGroupHTTP
 
+  # TLS listener terminates TLS using ACM certificate and forwards to port 80 HTTP target group
   EdgeNLBListenerHTTPS:
     Type: AWS::ElasticLoadBalancingV2::Listener
+    Condition: HasNLBCertificate
     Properties:
       LoadBalancerArn: !Ref EdgeNLB
       Port: 443
-      Protocol: TCP
+      Protocol: TLS
+      Certificates:
+        - CertificateArn: !Ref NLBCertificateArn
+      SslPolicy: ELBSecurityPolicy-TLS13-1-2-2021-06
       DefaultActions:
         - Type: forward
-          TargetGroupArn: !Ref EdgeNLBTargetGroupHTTPS
+          TargetGroupArn: !Ref EdgeNLBTargetGroupHTTP
 
 # Network Firewall - Inspects all inbound internet traffic before it reaches the NLB and spoke workloads
 # The firewall is deployed in the Firewall Subnet of the Edge VPC
@@ -763,6 +682,7 @@ Resources:
             HOME_NET:
               Definition:
                 - 10.0.0.0/8
+                - 100.64.0.0/16
                 - 172.16.0.0/12
                 - 192.168.0.0/16
       Tags:

--- a/centralized_architecture/centralized_ingress_single_az/anfw-centralized-ingress-1az-template.yaml
+++ b/centralized_architecture/centralized_ingress_single_az/anfw-centralized-ingress-1az-template.yaml
@@ -133,7 +133,7 @@ Resources:
       RoleName: !Sub "subnet-a-role-${AWS::StackName}"
       Path: "/"
       ManagedPolicyArns:
-        - "arn:aws:iam::aws:policy/service-role/AmazonEC2RoleforSSM"
+        - "arn:aws:iam::aws:policy/AmazonSSMManagedInstanceCore"
       AssumeRolePolicyDocument:
         Version: "2012-10-17"
         Statement:
@@ -154,7 +154,7 @@ Resources:
   SubnetASecGroup:
     Type: AWS::EC2::SecurityGroup
     Properties:
-      GroupDescription: "ICMP acess from 10.0.0.0/8 and inspection VPC, HTTP from inspection VPC and spoke VPC"
+      GroupDescription: "ICMP access from 10.0.0.0/8 and inspection VPC, HTTP from inspection VPC and spoke VPC"
       GroupName: !Sub "spoke-a-sec-group-${AWS::StackName}"
       VpcId: !Ref SpokeVPCA
       SecurityGroupIngress:
@@ -196,7 +196,7 @@ Resources:
         Fn::Base64: !Sub |
           #!/bin/bash
           # Wait for internet connectivity (egress path via NAT GW may take time to converge)
-          for i in $(seq 1 30); do curl -s --max-time 5 https://amazonlinux-2-repos-us-east-1.s3.dualstack.us-east-1.amazonaws.com && break || sleep 10; done
+          for i in $(seq 1 30); do curl -s --max-time 5 https://amazonlinux-2-repos-${AWS::Region}.s3.dualstack.${AWS::Region}.amazonaws.com && break || sleep 10; done
           yum install -y httpd
           systemctl start httpd
           systemctl enable httpd
@@ -296,7 +296,7 @@ Resources:
       RoleName: !Sub "subnet-b-role-${AWS::StackName}"
       Path: "/"
       ManagedPolicyArns:
-        - "arn:aws:iam::aws:policy/service-role/AmazonEC2RoleforSSM"
+        - "arn:aws:iam::aws:policy/AmazonSSMManagedInstanceCore"
       AssumeRolePolicyDocument:
         Version: "2012-10-17"
         Statement:
@@ -317,7 +317,7 @@ Resources:
   SubnetBSecGroup:
     Type: AWS::EC2::SecurityGroup
     Properties:
-      GroupDescription: "ICMP acess from 10.0.0.0/8 and inspection VPC, HTTP from inspection VPC and spoke VPC"
+      GroupDescription: "ICMP access from 10.0.0.0/8 and inspection VPC, HTTP from inspection VPC and spoke VPC"
       GroupName: !Sub "spoke-b-sec-group-${AWS::StackName}"
       VpcId: !Ref SpokeVPCB
       SecurityGroupIngress:
@@ -358,7 +358,7 @@ Resources:
       UserData:
         Fn::Base64: !Sub |
           #!/bin/bash
-          for i in $(seq 1 30); do curl -s --max-time 5 https://amazonlinux-2-repos-us-east-1.s3.dualstack.us-east-1.amazonaws.com && break || sleep 10; done
+          for i in $(seq 1 30); do curl -s --max-time 5 https://amazonlinux-2-repos-${AWS::Region}.s3.dualstack.${AWS::Region}.amazonaws.com && break || sleep 10; done
           yum install -y httpd
           systemctl start httpd
           systemctl enable httpd
@@ -532,6 +532,24 @@ Resources:
 # NLB is used for the single-AZ template because ALBs require a minimum of 2 AZs.
 # The 2AZ template uses an ALB instead, which provides Layer 7 features.
 # Spoke NLBs use static private IPs (via SubnetMappings) so they can be registered as Edge NLB targets directly.
+  EdgeNLBSecurityGroup:
+    Type: AWS::EC2::SecurityGroup
+    Properties:
+      GroupDescription: "Allow HTTP and TLS inbound traffic to Edge NLB"
+      GroupName: !Sub "edge-nlb-sg-${AWS::StackName}"
+      VpcId: !Ref EdgeVPC
+      SecurityGroupIngress:
+        - IpProtocol: tcp
+          CidrIp: 0.0.0.0/0
+          Description: "Allow HTTP from internet"
+          FromPort: 80
+          ToPort: 80
+        - IpProtocol: tcp
+          CidrIp: 0.0.0.0/0
+          Description: "Allow TLS from internet"
+          FromPort: 443
+          ToPort: 443
+
   EdgeNLB:
     Type: AWS::ElasticLoadBalancingV2::LoadBalancer
     DependsOn: AttachEdgeGateway
@@ -539,6 +557,8 @@ Resources:
       Name: !Sub "edge-nlb-${AWS::StackName}"
       Scheme: internet-facing
       Type: network
+      SecurityGroups:
+        - !Ref EdgeNLBSecurityGroup
       Subnets:
         - !Ref EdgePublicSubnet
       Tags:

--- a/centralized_architecture/centralized_ingress_single_az/anfw-centralized-ingress-1az-template.yaml
+++ b/centralized_architecture/centralized_ingress_single_az/anfw-centralized-ingress-1az-template.yaml
@@ -1,0 +1,1234 @@
+#Copyright 2021 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+
+#THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+#IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+#FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+#COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+#IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+#CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+AWSTemplateFormatVersion: "2010-09-09"
+Description: "AWS Network Firewall Demo - Centralized ingress inspection with Edge VPC, Network Firewall, NLB, Transit Gateway, and spoke VPCs with NLBs (single AZ deployment)"
+
+Metadata:
+  "AWS::CloudFormation::Interface":
+    ParameterGroups:
+      - Label:
+          default: "VPC Parameters"
+        Parameters:
+          - AvailabilityZoneSelection
+      - Label:
+          default: "EC2 Parameters"
+        Parameters:
+          - LatestAmiId
+Parameters:
+  AvailabilityZoneSelection:
+    Description: Availability Zone
+    Type: AWS::EC2::AvailabilityZone::Name
+    Default: us-east-1a
+
+  LatestAmiId:
+    Description: Latest EC2 AMI from Systems Manager Parameter Store
+    Type: 'AWS::SSM::Parameter::Value<AWS::EC2::Image::Id>'
+    Default: '/aws/service/ami-amazon-linux-latest/amzn2-ami-hvm-x86_64-gp2'
+
+Resources:
+# Spoke VPC A
+  SpokeVPCA:
+    Type: AWS::EC2::VPC
+    Properties:
+      CidrBlock: "10.1.0.0/16"
+      EnableDnsSupport: "true"
+      EnableDnsHostnames: "true"
+      InstanceTenancy: default
+      Tags:
+        - Key: Name
+          Value: !Sub "spoke-a-${AWS::StackName}"
+
+  SubnetAWorkload:
+    Type: AWS::EC2::Subnet
+    Properties:
+      VpcId:
+        Ref: SpokeVPCA
+      CidrBlock: "10.1.1.0/24"
+      AvailabilityZone: 
+        Ref: AvailabilityZoneSelection
+      MapPublicIpOnLaunch: false
+      Tags:
+        - Key: Name
+          Value: !Sub "spoke-a-workload-${AWS::StackName}"
+
+  SubnetATGW:
+    Type: AWS::EC2::Subnet
+    Properties:
+      VpcId:
+        Ref: SpokeVPCA
+      CidrBlock: "10.1.0.0/28"
+      AvailabilityZone:
+        Ref: AvailabilityZoneSelection
+      MapPublicIpOnLaunch: false
+      Tags:
+        - Key: Name
+          Value: !Sub "spoke-a-tgw-${AWS::StackName}"
+
+  SpokeAEndpointSecurityGroup:
+    Type: AWS::EC2::SecurityGroup
+    Properties:
+        GroupDescription: Allow instances to get to SSM Systems Manager
+        VpcId: !Ref SpokeVPCA
+        SecurityGroupIngress:
+        - IpProtocol: tcp
+          FromPort: 443
+          ToPort: 443
+          CidrIp: 10.1.0.0/16
+          Description: "Allow HTTPS traffic from Spoke A VPC for SSM access"
+  SpokeASSMEndpoint:
+    Type: AWS::EC2::VPCEndpoint
+    Properties: 
+        PrivateDnsEnabled: true
+        SecurityGroupIds: 
+          - !Ref SpokeAEndpointSecurityGroup
+        ServiceName: !Sub "com.amazonaws.${AWS::Region}.ssm"
+        SubnetIds: 
+          - !Ref SubnetAWorkload
+        VpcEndpointType: Interface
+        VpcId: !Ref SpokeVPCA
+
+  SpokeAEC2MessagesEndpoint:
+    Type: AWS::EC2::VPCEndpoint
+    Properties: 
+        PrivateDnsEnabled: true
+        SecurityGroupIds: 
+          - !Ref SpokeAEndpointSecurityGroup
+        ServiceName: !Sub "com.amazonaws.${AWS::Region}.ec2messages"
+        SubnetIds: 
+          - !Ref SubnetAWorkload
+        VpcEndpointType: Interface
+        VpcId: !Ref SpokeVPCA
+
+  SpokeASSMMessagesEndpoint:
+    Type: AWS::EC2::VPCEndpoint
+    Properties: 
+        PrivateDnsEnabled: true
+        SecurityGroupIds: 
+          - !Ref SpokeAEndpointSecurityGroup
+        ServiceName: !Sub "com.amazonaws.${AWS::Region}.ssmmessages"
+        SubnetIds: 
+          - !Ref SubnetAWorkload
+        VpcEndpointType: Interface
+        VpcId: !Ref SpokeVPCA
+ 
+  SubnetARole:
+    Type: AWS::IAM::Role
+    Properties:
+      RoleName: !Sub "subnet-a-role-${AWS::StackName}"
+      Path: "/"
+      ManagedPolicyArns:
+        - "arn:aws:iam::aws:policy/service-role/AmazonEC2RoleforSSM"
+      AssumeRolePolicyDocument:
+        Version: "2012-10-17"
+        Statement:
+          - Effect: Allow
+            Principal:
+              Service:
+                - ec2.amazonaws.com
+            Action:
+              - sts:AssumeRole
+
+  SubnetAInstanceProfile:
+    Type: AWS::IAM::InstanceProfile
+    Properties:
+      Path: "/"
+      Roles:
+        - !Ref SubnetARole
+        
+  SubnetASecGroup:
+    Type: AWS::EC2::SecurityGroup
+    Properties:
+      GroupDescription: "ICMP acess from 10.0.0.0/8 and inspection VPC, HTTP/HTTPS from inspection VPC and spoke VPC"
+      GroupName: !Sub "spoke-a-sec-group-${AWS::StackName}"
+      VpcId: !Ref SpokeVPCA
+      SecurityGroupIngress:
+        - IpProtocol: icmp
+          CidrIp: 10.0.0.0/8
+          Description: "Allow ICMP from private networks"
+          FromPort: "-1"
+          ToPort: "-1"
+        - IpProtocol: icmp
+          CidrIp: 100.64.0.0/16
+          Description: "Allow ICMP from Edge VPC"
+          FromPort: "-1"
+          ToPort: "-1"
+        - IpProtocol: tcp
+          CidrIp: 100.64.0.0/16
+          Description: "Allow HTTP from Edge VPC (NLB traffic)"
+          FromPort: 80
+          ToPort: 80
+        - IpProtocol: tcp
+          CidrIp: 100.64.0.0/16
+          Description: "Allow HTTPS from Edge VPC (NLB traffic)"
+          FromPort: 443
+          ToPort: 443
+        - IpProtocol: tcp
+          CidrIp: 10.1.0.0/16
+          Description: "Allow HTTP from Spoke A VPC (NLB health checks)"
+          FromPort: 80
+          ToPort: 80
+        - IpProtocol: tcp
+          CidrIp: 10.1.0.0/16
+          Description: "Allow HTTPS from Spoke A VPC (NLB health checks)"
+          FromPort: 443
+          ToPort: 443
+
+  EC2SubnetA:
+    Type: 'AWS::EC2::Instance'
+    DependsOn:
+      - EdgeTGWDefaultRoute
+      - SubnetAWorkloadDefaultRoute
+    Properties:
+      ImageId: !Ref LatestAmiId
+      SubnetId: !Ref SubnetAWorkload
+      InstanceType: t2.micro
+      SecurityGroupIds:
+        - !Ref SubnetASecGroup
+      IamInstanceProfile: !Ref SubnetAInstanceProfile
+      UserData:
+        Fn::Base64: !Sub |
+          #!/bin/bash
+          yum install -y httpd mod_ssl
+          systemctl start httpd
+          systemctl enable httpd
+          openssl req -x509 -nodes -days 365 -newkey rsa:2048 \
+            -keyout /etc/pki/tls/private/localhost.key \
+            -out /etc/pki/tls/certs/localhost.crt \
+            -subj "/CN=localhost"
+          systemctl restart httpd
+          echo "<html><body><h1>Spoke A - ${AvailabilityZoneSelection}</h1></body></html>" > /var/www/html/index.html
+      Tags:
+        - Key: Name
+          Value: !Sub "spoke-a-${AWS::StackName}"
+      
+# Spoke VPC B
+  SpokeVPCB:
+    Type: AWS::EC2::VPC
+    Properties:
+      CidrBlock: "10.2.0.0/16"
+      EnableDnsSupport: "true"
+      EnableDnsHostnames: "true"
+      InstanceTenancy: default
+      Tags:
+        - Key: Name
+          Value: !Sub "spoke-b-${AWS::StackName}"
+
+  SubnetBWorkload:
+    Type: AWS::EC2::Subnet
+    Properties:
+      VpcId:
+        Ref: SpokeVPCB
+      CidrBlock: "10.2.1.0/24"
+      AvailabilityZone:
+        Ref: AvailabilityZoneSelection
+      MapPublicIpOnLaunch: false
+      Tags:
+        - Key: Name
+          Value: !Sub "spoke-b-workload-${AWS::StackName}"
+
+  SubnetBTGW:
+    Type: AWS::EC2::Subnet
+    Properties:
+      VpcId:
+        Ref: SpokeVPCB
+      CidrBlock: "10.2.0.0/28"
+      AvailabilityZone:
+        Ref: AvailabilityZoneSelection
+      MapPublicIpOnLaunch: false
+      Tags:
+        - Key: Name
+          Value: !Sub "spoke-b-tgw-${AWS::StackName}"
+
+  SpokeBEndpointSecurityGroup:
+    Type: AWS::EC2::SecurityGroup
+    Properties:
+        GroupDescription: Allow instances to get to SSM Systems Manager
+        VpcId: !Ref SpokeVPCB
+        SecurityGroupIngress:
+        - IpProtocol: tcp
+          FromPort: 443
+          ToPort: 443
+          CidrIp: 10.2.0.0/16
+          Description: "Allow HTTPS traffic from Spoke B VPC for SSM access"
+  SpokeBSSMEndpoint:
+    Type: AWS::EC2::VPCEndpoint
+    Properties: 
+        PrivateDnsEnabled: true
+        SecurityGroupIds: 
+          - !Ref SpokeBEndpointSecurityGroup
+        ServiceName: !Sub "com.amazonaws.${AWS::Region}.ssm"
+        SubnetIds: 
+          - !Ref SubnetBWorkload
+        VpcEndpointType: Interface
+        VpcId: !Ref SpokeVPCB
+
+  SpokeBEC2MessagesEndpoint:
+    Type: AWS::EC2::VPCEndpoint
+    Properties: 
+        PrivateDnsEnabled: true
+        SecurityGroupIds: 
+          - !Ref SpokeBEndpointSecurityGroup
+        ServiceName: !Sub "com.amazonaws.${AWS::Region}.ec2messages"
+        SubnetIds: 
+          - !Ref SubnetBWorkload
+        VpcEndpointType: Interface
+        VpcId: !Ref SpokeVPCB
+
+  SpokeBSSMMessagesEndpoint:
+    Type: AWS::EC2::VPCEndpoint
+    Properties: 
+        PrivateDnsEnabled: true
+        SecurityGroupIds: 
+          - !Ref SpokeBEndpointSecurityGroup
+        ServiceName: !Sub "com.amazonaws.${AWS::Region}.ssmmessages"
+        SubnetIds: 
+          - !Ref SubnetBWorkload
+        VpcEndpointType: Interface
+        VpcId: !Ref SpokeVPCB
+
+  SubnetBRole:
+    Type: AWS::IAM::Role
+    Properties:
+      RoleName: !Sub "subnet-b-role-${AWS::StackName}"
+      Path: "/"
+      ManagedPolicyArns:
+        - "arn:aws:iam::aws:policy/service-role/AmazonEC2RoleforSSM"
+      AssumeRolePolicyDocument:
+        Version: "2012-10-17"
+        Statement:
+          - Effect: Allow
+            Principal:
+              Service:
+                - ec2.amazonaws.com
+            Action:
+              - sts:AssumeRole
+
+  SubnetBInstanceProfile:
+    Type: AWS::IAM::InstanceProfile
+    Properties:
+      Path: "/"
+      Roles:
+        - !Ref SubnetBRole
+        
+  SubnetBSecGroup:
+    Type: AWS::EC2::SecurityGroup
+    Properties:
+      GroupDescription: "ICMP acess from 10.0.0.0/8 and inspection VPC, HTTP/HTTPS from inspection VPC and spoke VPC"
+      GroupName: !Sub "spoke-b-sec-group-${AWS::StackName}"
+      VpcId: !Ref SpokeVPCB
+      SecurityGroupIngress:
+        - IpProtocol: icmp
+          CidrIp: 10.0.0.0/8
+          Description: "Allow ICMP from private networks"
+          FromPort: "-1"
+          ToPort: "-1"
+        - IpProtocol: icmp
+          CidrIp: 100.64.0.0/16
+          Description: "Allow ICMP from Edge VPC"
+          FromPort: "-1"
+          ToPort: "-1"
+        - IpProtocol: tcp
+          CidrIp: 100.64.0.0/16
+          Description: "Allow HTTP from Edge VPC (NLB traffic)"
+          FromPort: 80
+          ToPort: 80
+        - IpProtocol: tcp
+          CidrIp: 100.64.0.0/16
+          Description: "Allow HTTPS from Edge VPC (NLB traffic)"
+          FromPort: 443
+          ToPort: 443
+        - IpProtocol: tcp
+          CidrIp: 10.2.0.0/16
+          Description: "Allow HTTP from Spoke B VPC (NLB health checks)"
+          FromPort: 80
+          ToPort: 80
+        - IpProtocol: tcp
+          CidrIp: 10.2.0.0/16
+          Description: "Allow HTTPS from Spoke B VPC (NLB health checks)"
+          FromPort: 443
+          ToPort: 443
+
+  EC2SubnetB:
+    Type: 'AWS::EC2::Instance'
+    DependsOn:
+      - EdgeTGWDefaultRoute
+      - SubnetBWorkloadDefaultRoute
+    Properties:
+      ImageId: !Ref LatestAmiId
+      SubnetId: !Ref SubnetBWorkload
+      InstanceType: t2.micro
+      SecurityGroupIds:
+        - !Ref SubnetBSecGroup
+      IamInstanceProfile: !Ref SubnetBInstanceProfile
+      UserData:
+        Fn::Base64: !Sub |
+          #!/bin/bash
+          yum install -y httpd mod_ssl
+          systemctl start httpd
+          systemctl enable httpd
+          openssl req -x509 -nodes -days 365 -newkey rsa:2048 \
+            -keyout /etc/pki/tls/private/localhost.key \
+            -out /etc/pki/tls/certs/localhost.crt \
+            -subj "/CN=localhost"
+          systemctl restart httpd
+          echo "<html><body><h1>Spoke B - ${AvailabilityZoneSelection}</h1></body></html>" > /var/www/html/index.html
+      Tags:
+        - Key: Name
+          Value: !Sub "spoke-b-${AWS::StackName}"
+
+# Spoke NLB resources - Internal NLBs with static private IPs front EC2 workloads.
+# Static IPs allow the Edge VPC ALB to register spoke NLB targets directly in CloudFormation.
+  SpokeANLB:
+    Type: AWS::ElasticLoadBalancingV2::LoadBalancer
+    Properties:
+      Name: !Sub "spoke-a-nlb-${AWS::StackName}"
+      Scheme: internal
+      Type: network
+      SubnetMappings:
+        - SubnetId: !Ref SubnetAWorkload
+          PrivateIPv4Address: "10.1.1.10"
+      Tags:
+        - Key: Name
+          Value: !Sub "spoke-a-nlb-${AWS::StackName}"
+
+  SpokeANLBTargetGroupHTTP:
+    Type: AWS::ElasticLoadBalancingV2::TargetGroup
+    Properties:
+      Name: !Sub "spk-a-http-${AWS::StackName}"
+      Port: 80
+      Protocol: TCP
+      TargetType: instance
+      VpcId: !Ref SpokeVPCA
+      Targets:
+        - Id: !Ref EC2SubnetA
+      Tags:
+        - Key: Name
+          Value: !Sub "spoke-a-nlb-tg-http-${AWS::StackName}"
+
+  SpokeANLBListenerHTTP:
+    Type: AWS::ElasticLoadBalancingV2::Listener
+    Properties:
+      LoadBalancerArn: !Ref SpokeANLB
+      Port: 80
+      Protocol: TCP
+      DefaultActions:
+        - Type: forward
+          TargetGroupArn: !Ref SpokeANLBTargetGroupHTTP
+
+  SpokeANLBTargetGroupHTTPS:
+    Type: AWS::ElasticLoadBalancingV2::TargetGroup
+    Properties:
+      Name: !Sub "spk-a-https-${AWS::StackName}"
+      Port: 443
+      Protocol: TCP
+      TargetType: instance
+      VpcId: !Ref SpokeVPCA
+      Targets:
+        - Id: !Ref EC2SubnetA
+      Tags:
+        - Key: Name
+          Value: !Sub "spoke-a-nlb-tg-https-${AWS::StackName}"
+
+  SpokeANLBListenerHTTPS:
+    Type: AWS::ElasticLoadBalancingV2::Listener
+    Properties:
+      LoadBalancerArn: !Ref SpokeANLB
+      Port: 443
+      Protocol: TCP
+      DefaultActions:
+        - Type: forward
+          TargetGroupArn: !Ref SpokeANLBTargetGroupHTTPS
+
+  SpokeBNLB:
+    Type: AWS::ElasticLoadBalancingV2::LoadBalancer
+    Properties:
+      Name: !Sub "spoke-b-nlb-${AWS::StackName}"
+      Scheme: internal
+      Type: network
+      SubnetMappings:
+        - SubnetId: !Ref SubnetBWorkload
+          PrivateIPv4Address: "10.2.1.10"
+      Tags:
+        - Key: Name
+          Value: !Sub "spoke-b-nlb-${AWS::StackName}"
+
+  SpokeBNLBTargetGroupHTTP:
+    Type: AWS::ElasticLoadBalancingV2::TargetGroup
+    Properties:
+      Name: !Sub "spk-b-http-${AWS::StackName}"
+      Port: 80
+      Protocol: TCP
+      TargetType: instance
+      VpcId: !Ref SpokeVPCB
+      Targets:
+        - Id: !Ref EC2SubnetB
+      Tags:
+        - Key: Name
+          Value: !Sub "spoke-b-nlb-tg-http-${AWS::StackName}"
+
+  SpokeBNLBListenerHTTP:
+    Type: AWS::ElasticLoadBalancingV2::Listener
+    Properties:
+      LoadBalancerArn: !Ref SpokeBNLB
+      Port: 80
+      Protocol: TCP
+      DefaultActions:
+        - Type: forward
+          TargetGroupArn: !Ref SpokeBNLBTargetGroupHTTP
+
+  SpokeBNLBTargetGroupHTTPS:
+    Type: AWS::ElasticLoadBalancingV2::TargetGroup
+    Properties:
+      Name: !Sub "spk-b-https-${AWS::StackName}"
+      Port: 443
+      Protocol: TCP
+      TargetType: instance
+      VpcId: !Ref SpokeVPCB
+      Targets:
+        - Id: !Ref EC2SubnetB
+      Tags:
+        - Key: Name
+          Value: !Sub "spoke-b-nlb-tg-https-${AWS::StackName}"
+
+  SpokeBNLBListenerHTTPS:
+    Type: AWS::ElasticLoadBalancingV2::Listener
+    Properties:
+      LoadBalancerArn: !Ref SpokeBNLB
+      Port: 443
+      Protocol: TCP
+      DefaultActions:
+        - Type: forward
+          TargetGroupArn: !Ref SpokeBNLBTargetGroupHTTPS
+
+# Edge VPC - Central VPC hosting IGW, Network Firewall, ALB, and NAT Gateway
+# All inbound internet traffic enters through this VPC and is inspected by the firewall before reaching spoke workloads
+  EdgeVPC:
+    Type: AWS::EC2::VPC
+    Properties:
+      CidrBlock: "100.64.0.0/16"
+      EnableDnsSupport: "true"
+      EnableDnsHostnames: "true"
+      InstanceTenancy: default
+      Tags:
+        - Key: Name
+          Value: !Sub "edge-${AWS::StackName}"
+
+  EdgeFirewallSubnet:
+    Type: AWS::EC2::Subnet
+    Properties:
+      VpcId:
+        Ref: EdgeVPC
+      CidrBlock: "100.64.0.16/28"
+      AvailabilityZone:
+        Ref: AvailabilityZoneSelection
+      MapPublicIpOnLaunch: false
+      Tags:
+        - Key: Name
+          Value: !Sub "edge-firewall-${AWS::StackName}"
+
+  EdgePublicSubnet:
+    Type: AWS::EC2::Subnet
+    Properties:
+      VpcId:
+        Ref: EdgeVPC
+      CidrBlock: "100.64.1.0/24"
+      AvailabilityZone:
+        Ref: AvailabilityZoneSelection
+      MapPublicIpOnLaunch: true
+      Tags:
+        - Key: Name
+          Value: !Sub "edge-public-${AWS::StackName}"
+
+  EdgeTGWSubnet:
+    Type: AWS::EC2::Subnet
+    Properties:
+      VpcId:
+        Ref: EdgeVPC
+      CidrBlock: "100.64.0.0/28"
+      AvailabilityZone:
+        Ref: AvailabilityZoneSelection
+      MapPublicIpOnLaunch: false
+      Tags:
+        - Key: Name
+          Value: !Sub "edge-tgw-${AWS::StackName}"
+
+  EdgeInternetGateway:
+    Type: AWS::EC2::InternetGateway
+    Properties:
+      Tags:
+        - Key: Name
+          Value: !Sub "edge-igw-${AWS::StackName}"
+
+  AttachEdgeGateway:
+    Type: AWS::EC2::VPCGatewayAttachment
+    Properties:
+      VpcId:
+        !Ref EdgeVPC
+      InternetGatewayId:
+        !Ref EdgeInternetGateway
+
+  EdgeNATEIP:
+    Type: "AWS::EC2::EIP"
+    Properties:
+      Domain: vpc
+
+  EdgeNATGateway:
+    Type: "AWS::EC2::NatGateway"
+    Properties:
+      AllocationId:
+        Fn::GetAtt:
+          - EdgeNATEIP
+          - AllocationId
+      SubnetId:
+        Ref: EdgePublicSubnet
+      Tags:
+        - Key: Name
+          Value: !Sub "edge-natgw-${AWS::StackName}"
+
+# Edge VPC NLB - Internet-facing NLB receives inspected inbound traffic and forwards to spoke NLBs
+# NLB is used for the single-AZ template because ALBs require a minimum of 2 AZs.
+# The 2AZ template uses an ALB instead, which provides Layer 7 features.
+# Spoke NLBs use static private IPs (via SubnetMappings) so they can be registered as Edge NLB targets directly.
+  EdgeNLB:
+    Type: AWS::ElasticLoadBalancingV2::LoadBalancer
+    DependsOn: AttachEdgeGateway
+    Properties:
+      Name: !Sub "edge-nlb-${AWS::StackName}"
+      Scheme: internet-facing
+      Type: network
+      Subnets:
+        - !Ref EdgePublicSubnet
+      Tags:
+        - Key: Name
+          Value: !Sub "edge-nlb-${AWS::StackName}"
+
+  # IP-type target groups targeting spoke NLB static IPs via TGW
+  # Spoke A NLB: 10.1.1.10, Spoke B NLB: 10.2.1.10 (assigned via SubnetMappings PrivateIPv4Address)
+  # AvailabilityZone: "all" is required for cross-VPC IP targets routed via TGW
+  EdgeNLBTargetGroupHTTP:
+    Type: AWS::ElasticLoadBalancingV2::TargetGroup
+    Properties:
+      Name: !Sub "e-tg-http-${AWS::StackName}"
+      Port: 80
+      Protocol: TCP
+      TargetType: ip
+      VpcId: !Ref EdgeVPC
+      Targets:
+        - Id: "10.1.1.10"
+          AvailabilityZone: "all"
+        - Id: "10.2.1.10"
+          AvailabilityZone: "all"
+      Tags:
+        - Key: Name
+          Value: !Sub "e-tg-http-${AWS::StackName}"
+
+  EdgeNLBTargetGroupHTTPS:
+    Type: AWS::ElasticLoadBalancingV2::TargetGroup
+    Properties:
+      Name: !Sub "e-tg-https-${AWS::StackName}"
+      Port: 443
+      Protocol: TCP
+      TargetType: ip
+      VpcId: !Ref EdgeVPC
+      Targets:
+        - Id: "10.1.1.10"
+          AvailabilityZone: "all"
+        - Id: "10.2.1.10"
+          AvailabilityZone: "all"
+      Tags:
+        - Key: Name
+          Value: !Sub "e-tg-https-${AWS::StackName}"
+
+  EdgeNLBListenerHTTP:
+    Type: AWS::ElasticLoadBalancingV2::Listener
+    Properties:
+      LoadBalancerArn: !Ref EdgeNLB
+      Port: 80
+      Protocol: TCP
+      DefaultActions:
+        - Type: forward
+          TargetGroupArn: !Ref EdgeNLBTargetGroupHTTP
+
+  EdgeNLBListenerHTTPS:
+    Type: AWS::ElasticLoadBalancingV2::Listener
+    Properties:
+      LoadBalancerArn: !Ref EdgeNLB
+      Port: 443
+      Protocol: TCP
+      DefaultActions:
+        - Type: forward
+          TargetGroupArn: !Ref EdgeNLBTargetGroupHTTPS
+
+# Network Firewall - Inspects all inbound internet traffic before it reaches the NLB and spoke workloads
+# The firewall is deployed in the Firewall Subnet of the Edge VPC
+
+  IngressAllowListRuleGroup:
+    Type: 'AWS::NetworkFirewall::RuleGroup'
+    Properties:
+      RuleGroupName: ingress-allow-list-rule-group
+      Type: STATEFUL
+      RuleGroup:
+        RulesSource:
+          RulesString: |
+            # Strict rule ordering ingress security template
+            # This rule group is defined but NOT referenced in the firewall policy by default.
+            # Enable it by adding a StatefulRuleGroupReference to the IngressFirewallPolicy when
+            # you are ready to move beyond log-only mode.
+            # Visit https://aws.github.io/aws-security-services-best-practices/guides/network-firewall/ for best practices
+
+            # Allow inbound HTTP to HOME_NET (for ALB health checks and web traffic)
+            pass tcp any any -> $HOME_NET 80 (flow:to_server; msg:"Allow inbound HTTP"; sid:300001;)
+
+            # Allow inbound HTTPS to HOME_NET
+            pass tcp any any -> $HOME_NET 443 (flow:to_server; msg:"Allow inbound HTTPS"; sid:300002;)
+
+            # Allow established return traffic from HOME_NET
+            pass tcp $HOME_NET any -> any any (flow:established,to_client; msg:"Allow established outbound"; sid:300003;)
+
+            # Alert on risky source geos
+            alert ip any any -> $HOME_NET any (msg:"Ingress from RU"; flow:to_server; geoip:src,RU; metadata:geo RU; sid:300004;)
+            alert ip any any -> $HOME_NET any (msg:"Ingress from CN"; flow:to_server; geoip:src,CN; metadata:geo CN; sid:300005;)
+
+            # Drop all other inbound traffic
+            drop tcp any any -> $HOME_NET any (msg:"Default Ingress TCP Drop"; flow:to_server; sid:399991;)
+            drop udp any any -> $HOME_NET any (msg:"Default Ingress UDP Drop"; flow:to_server; sid:399992;)
+            drop icmp any any -> $HOME_NET any (msg:"Default Ingress ICMP Drop"; sid:399993;)
+            drop ip any any -> $HOME_NET any (msg:"Default Ingress IP Drop"; ip_proto:!TCP; ip_proto:!UDP; ip_proto:!ICMP; flow:to_server; sid:399994;)
+        StatefulRuleOptions:
+          RuleOrder: STRICT_ORDER
+      Capacity: 1000
+      Description: Comprehensive ingress allow-list rule group (defined but not referenced in policy by default)
+
+  IngressLogOnlyRuleGroup:
+    Type: 'AWS::NetworkFirewall::RuleGroup'
+    Properties:
+      RuleGroupName: ingress-log-only-rules
+      Type: STATEFUL
+      RuleGroup:
+        RulesSource:
+          RulesString: |
+            # Ingress inspection log-only rules - Strict rule ordering
+            # This rule group alerts on inbound traffic patterns without blocking.
+            # Visit https://aws.github.io/aws-security-services-best-practices/guides/network-firewall/ for best practices
+
+            # Alert on inbound HTTP traffic
+            alert http any any -> $HOME_NET any (msg:"Inbound HTTP traffic"; flow:to_server; sid:200001;)
+
+            # Alert on inbound HTTPS/TLS traffic
+            alert tls any any -> $HOME_NET any (msg:"Inbound TLS traffic"; flow:to_server; sid:200002;)
+
+            # Alert on inbound SSH
+            alert ssh any any -> $HOME_NET any (msg:"Inbound SSH traffic"; flow:to_server; sid:200003;)
+
+            # Alert on inbound ICMP
+            alert icmp any any -> $HOME_NET any (msg:"Inbound ICMP traffic"; sid:200004;)
+
+            # Alert on any other inbound traffic
+            alert ip any any -> $HOME_NET any (msg:"Inbound IP traffic"; flow:to_server; sid:200005;)
+        StatefulRuleOptions:
+          RuleOrder: STRICT_ORDER
+      Capacity: 100
+      Description: Simple ingress log-only rule group to alert on inbound traffic patterns without blocking
+
+  IngressFirewallPolicy:
+    Type: AWS::NetworkFirewall::FirewallPolicy
+    Properties:
+      FirewallPolicyName: !Sub "ingress-firewall-policy-${AWS::StackName}"
+      FirewallPolicy:
+        StatelessDefaultActions:
+          - 'aws:forward_to_sfe'
+        StatelessFragmentDefaultActions:
+          - 'aws:forward_to_sfe'
+        StatefulRuleGroupReferences:
+          - ResourceArn: !Ref IngressLogOnlyRuleGroup
+            Priority: 100
+        StatefulEngineOptions:
+          RuleOrder: STRICT_ORDER
+          StreamExceptionPolicy: REJECT
+        PolicyVariables:
+          RuleVariables:
+            HOME_NET:
+              Definition:
+                - 10.0.0.0/8
+                - 172.16.0.0/12
+                - 192.168.0.0/16
+      Tags:
+        - Key: Name
+          Value: !Sub "ingress-firewall-policy-${AWS::StackName}"
+
+  IngressFirewall:
+    Type: AWS::NetworkFirewall::Firewall
+    Properties:
+      FirewallName: !Sub "ingress-firewall-${AWS::StackName}"
+      FirewallPolicyArn: !Ref IngressFirewallPolicy
+      VpcId: !Ref EdgeVPC
+      SubnetMappings:
+        - SubnetId: !Ref EdgeFirewallSubnet
+      Tags:
+        - Key: Name
+          Value: !Sub "ingress-firewall-${AWS::StackName}"
+
+  IngressFirewallLogFlowGroup:
+    Type: AWS::Logs::LogGroup
+    Metadata:
+      checkov:
+        skip:
+          - id: "CKV_AWS_158"
+            comment: "Ensure that CloudWatch Log Group is encrypted by KMS"
+    Properties:
+      LogGroupName: !Sub "/${AWS::StackName}/ingress-fw/flow"
+      RetentionInDays: 30
+
+  IngressFirewallLogAlertGroup:
+    Type: AWS::Logs::LogGroup
+    Metadata:
+      checkov:
+        skip:
+          - id: "CKV_AWS_158"
+            comment: "Ensure that CloudWatch Log Group is encrypted by KMS"
+    Properties:
+      LogGroupName: !Sub "/${AWS::StackName}/ingress-fw/alert"
+      RetentionInDays: 30
+
+  IngressFirewallLog:
+    Type: AWS::NetworkFirewall::LoggingConfiguration
+    Properties:
+      FirewallArn: !Ref IngressFirewall
+      LoggingConfiguration:
+        LogDestinationConfigs:
+          - LogType: FLOW
+            LogDestinationType: CloudWatchLogs
+            LogDestination:
+              logGroup: !Sub "/${AWS::StackName}/ingress-fw/flow"
+          - LogType: ALERT
+            LogDestinationType: CloudWatchLogs
+            LogDestination:
+              logGroup: !Sub "/${AWS::StackName}/ingress-fw/alert"
+
+# Transit Gateway - Connects Edge VPC to Spoke VPCs
+# Spoke traffic routes through TGW to the Edge VPC for inspection, and return traffic flows back via TGW
+  CentralTransitGateway:
+    Type: "AWS::EC2::TransitGateway"
+    Properties:
+      AmazonSideAsn: 65000
+      Description: "TGW Centralized Ingress Inspection"
+      AutoAcceptSharedAttachments: "disable"
+      DefaultRouteTableAssociation: "disable"
+      DefaultRouteTablePropagation: "disable"
+      DnsSupport: "enable"
+      VpnEcmpSupport: "enable"
+      Tags:
+        - Key: Name
+          Value: !Sub "tgw-${AWS::StackName}"
+
+  # Edge VPC attachment with ApplianceModeSupport to ensure symmetric routing through the firewall
+  AttachEdgeVPC:
+    Type: "AWS::EC2::TransitGatewayAttachment"
+    Properties:
+      SubnetIds:
+        - !Ref EdgeTGWSubnet
+      Options:
+        ApplianceModeSupport: enable
+      Tags:
+        - Key: Name
+          Value: !Sub "edge-attach-${AWS::StackName}"
+      TransitGatewayId: !Ref CentralTransitGateway
+      VpcId: !Ref EdgeVPC
+
+  AttachSpokeVPCA:
+    Type: "AWS::EC2::TransitGatewayAttachment"
+    Properties:
+      SubnetIds:
+        - !Ref SubnetATGW
+      Tags:
+        - Key: Name
+          Value: !Sub "spoke-a-attach-${AWS::StackName}"
+      TransitGatewayId: !Ref CentralTransitGateway
+      VpcId: !Ref SpokeVPCA
+
+  AttachSpokeVPCB:
+    Type: "AWS::EC2::TransitGatewayAttachment"
+    Properties:
+      SubnetIds:
+        - !Ref SubnetBTGW
+      Tags:
+        - Key: Name
+          Value: !Sub "spoke-b-attach-${AWS::StackName}"
+      TransitGatewayId: !Ref CentralTransitGateway
+      VpcId: !Ref SpokeVPCB
+
+  # Transit Gateway Route Tables
+  SpokeRouteTable:
+    Type: "AWS::EC2::TransitGatewayRouteTable"
+    Properties:
+      Tags:
+        - Key: Name
+          Value: !Sub "spoke-route-table-${AWS::StackName}"
+      TransitGatewayId: !Ref CentralTransitGateway
+
+  InspectionRouteTable:
+    Type: "AWS::EC2::TransitGatewayRouteTable"
+    Properties:
+      Tags:
+        - Key: Name
+          Value: !Sub "inspection-route-table-${AWS::StackName}"
+      TransitGatewayId: !Ref CentralTransitGateway
+
+  # Associate both spoke attachments with the Spoke TGW route table
+  AssociateVPCARouteTable:
+    Type: AWS::EC2::TransitGatewayRouteTableAssociation
+    Properties:
+      TransitGatewayAttachmentId: !Ref AttachSpokeVPCA
+      TransitGatewayRouteTableId: !Ref SpokeRouteTable
+
+  AssociateVPCBRouteTable:
+    Type: AWS::EC2::TransitGatewayRouteTableAssociation
+    Properties:
+      TransitGatewayAttachmentId: !Ref AttachSpokeVPCB
+      TransitGatewayRouteTableId: !Ref SpokeRouteTable
+
+  # Associate Edge VPC attachment with the Inspection TGW route table
+  AssociateEdgeVPCRouteTable:
+    Type: AWS::EC2::TransitGatewayRouteTableAssociation
+    Properties:
+      TransitGatewayAttachmentId: !Ref AttachEdgeVPC
+      TransitGatewayRouteTableId: !Ref InspectionRouteTable
+
+  # Propagate spoke routes to inspection route table for return traffic
+  PropagateVPCARoute:
+    Type: AWS::EC2::TransitGatewayRouteTablePropagation
+    Properties:
+      TransitGatewayAttachmentId: !Ref AttachSpokeVPCA
+      TransitGatewayRouteTableId: !Ref InspectionRouteTable
+
+  PropagateVPCBRoute:
+    Type: AWS::EC2::TransitGatewayRouteTablePropagation
+    Properties:
+      TransitGatewayAttachmentId: !Ref AttachSpokeVPCB
+      TransitGatewayRouteTableId: !Ref InspectionRouteTable
+
+  # Route all spoke traffic to Edge VPC for inspection
+  SpokeDefaultRoute:
+    Type: AWS::EC2::TransitGatewayRoute
+    Properties:
+      DestinationCidrBlock: "0.0.0.0/0"
+      TransitGatewayAttachmentId: !Ref AttachEdgeVPC
+      TransitGatewayRouteTableId: !Ref SpokeRouteTable
+
+# Edge VPC Route Tables - Ingress-specific routing for symmetric firewall inspection
+# Key differences from the egress template:
+#   - Public Subnet routes 0.0.0.0/0 → Firewall Endpoint for symmetric ingress inspection
+#   - Firewall Subnet routes 0.0.0.0/0 → IGW as the exit point for inspected traffic
+#   - TGW Subnet routes 0.0.0.0/0 → NAT Gateway for spoke egress NAT translation
+#   - IGW Ingress Route Table steers inbound traffic through firewall before reaching NLB
+
+  # IGW Ingress Route Table - Associated with the Internet Gateway
+  # Routes inbound traffic destined for the Public Subnet through the firewall endpoint
+  # This is the key construct enabling ingress inspection: traffic arriving at the IGW
+  # for the NLB (in the Public Subnet) is redirected to the firewall first
+  EdgeIGWIngressRouteTable:
+    Type: AWS::EC2::RouteTable
+    Properties:
+      VpcId: !Ref EdgeVPC
+      Tags:
+        - Key: Name
+          Value: !Sub "edge-igw-ingress-route-table-${AWS::StackName}"
+
+  EdgeIGWIngressRouteTableAssociation:
+    Type: AWS::EC2::GatewayRouteTableAssociation
+    Properties:
+      RouteTableId: !Ref EdgeIGWIngressRouteTable
+      GatewayId: !Ref EdgeInternetGateway
+
+  # Route traffic destined for the Public Subnet CIDR through the firewall endpoint
+  EdgeIGWIngressPublicSubnetRoute:
+    Type: AWS::EC2::Route
+    DependsOn: IngressFirewall
+    Properties:
+      DestinationCidrBlock: "100.64.1.0/24"
+      VpcEndpointId: !Select [1, !Split [":", !Select [0, !GetAtt IngressFirewall.EndpointIds]]]
+      RouteTableId: !Ref EdgeIGWIngressRouteTable
+
+  # Firewall Subnet Route Table
+  # 0.0.0.0/0 → IGW: After the firewall inspects traffic (both ingress return from NLB and
+  # NAT'd spoke egress), the Firewall Subnet forwards it to the IGW for internet delivery.
+  # This is the exit point for ALL inspected outbound traffic.
+  # 10.0.0.0/8 → TGW: Forward inspected inbound traffic to spoke VPCs via Transit Gateway.
+  EdgeFirewallRouteTable:
+    Type: AWS::EC2::RouteTable
+    Properties:
+      VpcId: !Ref EdgeVPC
+      Tags:
+        - Key: Name
+          Value: !Sub "edge-firewall-route-table-${AWS::StackName}"
+
+  EdgeFirewallRouteTableAssociation:
+    Type: AWS::EC2::SubnetRouteTableAssociation
+    DependsOn: EdgeFirewallSubnet
+    Properties:
+      RouteTableId: !Ref EdgeFirewallRouteTable
+      SubnetId: !Ref EdgeFirewallSubnet
+
+  EdgeFirewallDefaultRoute:
+    Type: AWS::EC2::Route
+    DependsOn: AttachEdgeGateway
+    Properties:
+      DestinationCidrBlock: "0.0.0.0/0"
+      GatewayId: !Ref EdgeInternetGateway
+      RouteTableId: !Ref EdgeFirewallRouteTable
+
+  EdgeFirewallTGWRoute:
+    Type: AWS::EC2::Route
+    DependsOn: AttachEdgeVPC
+    Properties:
+      DestinationCidrBlock: "10.0.0.0/8"
+      TransitGatewayId: !Ref CentralTransitGateway
+      RouteTableId: !Ref EdgeFirewallRouteTable
+
+  # Public Subnet Route Table
+  # 0.0.0.0/0 → Firewall Endpoint: CRITICAL for symmetric ingress inspection.
+  # NLB return traffic and NAT Gateway egress traffic both pass through the firewall
+  # before reaching the Firewall Subnet (which then routes to the IGW).
+  # Without this route, NLB return traffic would bypass the firewall and go directly
+  # to the IGW, causing the stateful firewall to see only the inbound direction
+  # and drop return packets (asymmetric routing).
+  # 10.0.0.0/8 → TGW: Edge NLB-to-spoke traffic goes directly to TGW.
+  EdgePublicRouteTable:
+    Type: AWS::EC2::RouteTable
+    Properties:
+      VpcId: !Ref EdgeVPC
+      Tags:
+        - Key: Name
+          Value: !Sub "edge-public-route-table-${AWS::StackName}"
+
+  EdgePublicRouteTableAssociation:
+    Type: AWS::EC2::SubnetRouteTableAssociation
+    DependsOn: EdgePublicSubnet
+    Properties:
+      RouteTableId: !Ref EdgePublicRouteTable
+      SubnetId: !Ref EdgePublicSubnet
+
+  EdgePublicDefaultRoute:
+    Type: AWS::EC2::Route
+    DependsOn: IngressFirewall
+    Properties:
+      DestinationCidrBlock: "0.0.0.0/0"
+      VpcEndpointId: !Select [1, !Split [":", !Select [0, !GetAtt IngressFirewall.EndpointIds]]]
+      RouteTableId: !Ref EdgePublicRouteTable
+
+  EdgePublicTGWRoute:
+    Type: AWS::EC2::Route
+    DependsOn: AttachEdgeVPC
+    Properties:
+      DestinationCidrBlock: "10.0.0.0/8"
+      TransitGatewayId: !Ref CentralTransitGateway
+      RouteTableId: !Ref EdgePublicRouteTable
+
+  # TGW Subnet Route Table
+  # 0.0.0.0/0 → NAT Gateway: Spoke egress traffic (e.g., yum install, SSM) enters the
+  # Edge VPC via TGW and is sent to the NAT Gateway for source address translation.
+  # The NAT Gateway's outbound traffic then follows the Public Subnet route table
+  # (0.0.0.0/0 → Firewall Endpoint), ensuring spoke egress is inspected symmetrically.
+  EdgeTGWRouteTable:
+    Type: AWS::EC2::RouteTable
+    Properties:
+      VpcId: !Ref EdgeVPC
+      Tags:
+        - Key: Name
+          Value: !Sub "edge-tgw-route-table-${AWS::StackName}"
+
+  EdgeTGWRouteTableAssociation:
+    Type: AWS::EC2::SubnetRouteTableAssociation
+    DependsOn: EdgeTGWSubnet
+    Properties:
+      RouteTableId: !Ref EdgeTGWRouteTable
+      SubnetId: !Ref EdgeTGWSubnet
+
+  EdgeTGWDefaultRoute:
+    Type: AWS::EC2::Route
+    DependsOn: EdgeNATGateway
+    Properties:
+      DestinationCidrBlock: "0.0.0.0/0"
+      NatGatewayId: !Ref EdgeNATGateway
+      RouteTableId: !Ref EdgeTGWRouteTable
+
+# Spoke VPC Route Tables
+# Workload subnets route all traffic to TGW for centralized inspection
+# TGW subnets use default local routes only
+
+  # Spoke A workload subnet route table
+  SubnetAWorkloadRouteTable:
+    Type: AWS::EC2::RouteTable
+    Properties:
+      VpcId: !Ref SpokeVPCA
+      Tags:
+        - Key: Name
+          Value: !Sub "spoke-a-workload-route-table-${AWS::StackName}"
+
+  SubnetAWorkloadRouteTableAssociation:
+    Type: AWS::EC2::SubnetRouteTableAssociation
+    DependsOn: SubnetAWorkload
+    Properties:
+      RouteTableId: !Ref SubnetAWorkloadRouteTable
+      SubnetId: !Ref SubnetAWorkload
+
+  SubnetAWorkloadDefaultRoute:
+    Type: AWS::EC2::Route
+    DependsOn: AttachSpokeVPCA
+    Properties:
+      DestinationCidrBlock: "0.0.0.0/0"
+      TransitGatewayId: !Ref CentralTransitGateway
+      RouteTableId: !Ref SubnetAWorkloadRouteTable
+
+  # Spoke B workload subnet route table
+  SubnetBWorkloadRouteTable:
+    Type: AWS::EC2::RouteTable
+    Properties:
+      VpcId: !Ref SpokeVPCB
+      Tags:
+        - Key: Name
+          Value: !Sub "spoke-b-workload-route-table-${AWS::StackName}"
+
+  SubnetBWorkloadRouteTableAssociation:
+    Type: AWS::EC2::SubnetRouteTableAssociation
+    DependsOn: SubnetBWorkload
+    Properties:
+      RouteTableId: !Ref SubnetBWorkloadRouteTable
+      SubnetId: !Ref SubnetBWorkload
+
+  SubnetBWorkloadDefaultRoute:
+    Type: AWS::EC2::Route
+    DependsOn: AttachSpokeVPCB
+    Properties:
+      DestinationCidrBlock: "0.0.0.0/0"
+      TransitGatewayId: !Ref CentralTransitGateway
+      RouteTableId: !Ref SubnetBWorkloadRouteTable
+
+  # Dedicated route tables for TGW subnets (default local routes only)
+  SubnetATGWRouteTable:
+    Type: AWS::EC2::RouteTable
+    Properties:
+      VpcId: !Ref SpokeVPCA
+      Tags:
+        - Key: Name
+          Value: !Sub "spoke-a-tgw-route-table-${AWS::StackName}"
+
+  SubnetATGWRouteTableAssociation:
+    Type: AWS::EC2::SubnetRouteTableAssociation
+    DependsOn: SubnetATGW
+    Properties:
+      RouteTableId: !Ref SubnetATGWRouteTable
+      SubnetId: !Ref SubnetATGW
+
+  SubnetBTGWRouteTable:
+    Type: AWS::EC2::RouteTable
+    Properties:
+      VpcId: !Ref SpokeVPCB
+      Tags:
+        - Key: Name
+          Value: !Sub "spoke-b-tgw-route-table-${AWS::StackName}"
+
+  SubnetBTGWRouteTableAssociation:
+    Type: AWS::EC2::SubnetRouteTableAssociation
+    DependsOn: SubnetBTGW
+    Properties:
+      RouteTableId: !Ref SubnetBTGWRouteTable
+      SubnetId: !Ref SubnetBTGW
+
+# ============================================================================
+# Traffic Flow Summary:
+#
+# INGRESS PATH:
+#   Internet → IGW → (IGW Ingress RT: Public CIDR → FW Endpoint) → Firewall
+#   → (local route) → NLB in Public Subnet → (Public RT: 10.0.0.0/8 → TGW)
+#   → TGW → Spoke NLB → EC2 httpd
+#
+# INGRESS RETURN (symmetric through firewall):
+#   EC2 → Spoke NLB → TGW → Edge NLB → (Public RT: 0.0.0.0/0 → FW Endpoint)
+#   → Firewall → (Firewall RT: 0.0.0.0/0 → IGW) → Internet
+#
+# SPOKE EGRESS (e.g., yum install, SSM):
+#   Spoke EC2 → TGW → (TGW Subnet RT: 0.0.0.0/0 → NAT GW) → NAT Gateway
+#   → (Public RT: 0.0.0.0/0 → FW Endpoint) → Firewall
+#   → (Firewall RT: 0.0.0.0/0 → IGW) → Internet
+# ============================================================================
+
+Outputs:
+  IngressFirewallEndpoint:
+    Description: Ingress Network Firewall Endpoint ID
+    Value: !Select [1, !Split [":", !Select [0, !GetAtt IngressFirewall.EndpointIds]]]
+    Export:
+      Name: !Sub "${AWS::StackName}-IngressFirewallEndpoint"
+
+  TransitGatewayId:
+    Description: Transit Gateway ID
+    Value: !Ref CentralTransitGateway
+    Export:
+      Name: !Sub "${AWS::StackName}-TransitGatewayId"
+
+  EdgeNLBDNSName:
+    Description: Edge NLB DNS Name
+    Value: !GetAtt EdgeNLB.DNSName
+    Export:
+      Name: !Sub "${AWS::StackName}-EdgeNLBDNSName"
+
+  EdgeNATGatewayId:
+    Description: Edge NAT Gateway ID
+    Value: !Ref EdgeNATGateway
+    Export:
+      Name: !Sub "${AWS::StackName}-EdgeNATGateway"
+
+  EdgeNATEIPAllocationId:
+    Description: Edge NAT Gateway Elastic IP
+    Value: !Ref EdgeNATEIP
+    Export:
+      Name: !Sub "${AWS::StackName}-EdgeNATEIP"
+
+  SpokeASecurityGroupId:
+    Description: Spoke A Security Group ID
+    Value: !Ref SubnetASecGroup
+    Export:
+      Name: !Sub "${AWS::StackName}-SpokeASecGroup"
+
+  SpokeBSecurityGroupId:
+    Description: Spoke B Security Group ID
+    Value: !Ref SubnetBSecGroup
+    Export:
+      Name: !Sub "${AWS::StackName}-SpokeBSecGroup"
+
+  SpokeANLBDNSName:
+    Description: "Spoke A NLB DNS Name (static IP: 10.1.1.10)"
+    Value: !GetAtt SpokeANLB.DNSName
+    Export:
+      Name: !Sub "${AWS::StackName}-SpokeANLBDNSName"
+
+  SpokeBNLBDNSName:
+    Description: "Spoke B NLB DNS Name (static IP: 10.2.1.10)"
+    Value: !GetAtt SpokeBNLB.DNSName
+    Export:
+      Name: !Sub "${AWS::StackName}-SpokeBNLBDNSName"
+
+  SpokeRouteTableId:
+    Description: Spoke TGW Route Table ID
+    Value: !Ref SpokeRouteTable
+    Export:
+      Name: !Sub "${AWS::StackName}-SpokeRouteTable"
+
+  InspectionRouteTableId:
+    Description: Inspection TGW Route Table ID
+    Value: !Ref InspectionRouteTable
+    Export:
+      Name: !Sub "${AWS::StackName}-InspectionRouteTable"
+
+  EdgeVPCAttachmentId:
+    Description: Edge VPC TGW Attachment ID
+    Value: !Ref AttachEdgeVPC
+    Export:
+      Name: !Sub "${AWS::StackName}-EdgeVPCAttachment"

--- a/centralized_architecture/centralized_ingress_two_az/README.md
+++ b/centralized_architecture/centralized_ingress_two_az/README.md
@@ -1,0 +1,122 @@
+# Centralized Ingress Inspection - Two AZ Deployment
+
+**Template File:** [anfw-centralized-ingress-2az-template.yaml](anfw-centralized-ingress-2az-template.yaml)
+
+This template deploys AWS Network Firewall in a centralized ingress inspection architecture across two Availability Zones. All inbound internet traffic is routed through the Network Firewall in an Edge VPC before reaching application workloads in spoke VPCs via Transit Gateway. This configuration provides high availability and is recommended for production environments.
+
+## Architecture Overview
+
+This multi-AZ deployment creates a centralized ingress inspection model using an Edge VPC with an internet-facing Application Load Balancer, AWS Network Firewall endpoints in each AZ, and AWS Transit Gateway. Inbound traffic from the internet enters through the Edge VPC Internet Gateway, is steered through the Network Firewall for inspection via an IGW Ingress Route Table, and then reaches the Edge ALB. The ALB terminates TLS and forwards plaintext HTTP to spoke VPC NLBs via Transit Gateway, which distribute traffic to EC2 instances running httpd.
+
+## Resources Created
+
+### Edge VPC (100.64.0.0/16)
+Centralized VPC for ingress traffic inspection across two AZs:
+- **Firewall Subnets** (100.64.0.16/28, 100.64.0.32/28) - Contains AWS Network Firewall endpoints in each AZ
+- **Public Subnets** (100.64.1.0/24, 100.64.2.0/24) - Contains the internet-facing ALB and NAT Gateways
+- **TGW Subnets** (100.64.0.0/28, 100.64.0.48/28) - Attachment points for Transit Gateway
+- **Internet Gateway** - Entry point for inbound internet traffic
+- **NAT Gateways** (one per AZ) - Provide outbound internet access for spoke EC2 instances (package installation, SSM)
+
+### AWS Network Firewall
+- Firewall endpoints deployed in both AZs of the Edge VPC
+- Firewall policy with STRICT_ORDER rule ordering and REJECT stream exception
+- Log-only Suricata rule group for ingress traffic (alerts on HTTP, HTTPS, SSH, ICMP)
+- Comprehensive allow-list rule group (defined but not referenced in policy by default)
+- CloudWatch logging for both ALERT and FLOW log types (30-day retention)
+
+### Spoke VPCs
+Two example workload VPCs demonstrating end-to-end ingress traffic flow:
+- **Spoke A** (10.1.0.0/16) - Workload subnets, TGW subnets, EC2 instances with httpd (port 80) in each AZ
+- **Spoke B** (10.2.0.0/16) - Workload subnets, TGW subnets, EC2 instances with httpd (port 80) in each AZ
+- Internal NLBs with static private IPs fronting EC2 instances in each spoke (TCP port 80 only)
+- SSM VPC endpoints for instance management
+- Security groups allowing ICMP and HTTP from required CIDRs
+
+### Edge ALB
+- Internet-facing Application Load Balancer in the Edge VPC Public Subnets
+- HTTPS listener on port 443 that terminates TLS using an ACM certificate and forwards to port 80 (conditional on `ALBCertificateArn` parameter)
+- HTTP listener on port 80
+- Single IP-type target group (port 80, HTTP) with spoke NLB static IPs pre-registered
+- Security group allowing inbound HTTP and HTTPS from 0.0.0.0/0
+
+### Transit Gateway
+- Central routing hub connecting Edge VPC and spoke VPCs
+- Spoke route table with default route to Edge VPC attachment
+- Inspection route table with propagated spoke routes
+- Appliance Mode enabled on the Edge VPC attachment for flow symmetry
+
+## Traffic Flow
+
+### Ingress Path (Internet → Application)
+1. Client request arrives at the Internet Gateway
+2. IGW Ingress Route Table steers traffic to the Network Firewall endpoint in the same AZ (Public Subnet CIDR → Firewall Endpoint)
+3. Network Firewall inspects the inbound traffic using Suricata stateful rules
+4. Inspected traffic reaches the Edge ALB in the Public Subnet via VPC local route
+5. ALB terminates TLS (if HTTPS) and forwards HTTP to spoke NLB IPs via Transit Gateway (Public Subnet routes 10.0.0.0/8 → TGW)
+6. Spoke NLB distributes traffic to EC2 instances running httpd on port 80
+
+### Ingress Return Path (Application → Internet) — Symmetric
+1. EC2 response returns through the spoke NLB → Transit Gateway → Edge ALB
+2. Edge ALB sends the response to the client; Public Subnet routes 0.0.0.0/0 → **Firewall Endpoint** (same AZ)
+3. Network Firewall inspects the return traffic (matching the stateful flow from the inbound path)
+4. Firewall Subnet routes 0.0.0.0/0 → **Internet Gateway**; response exits to the internet
+
+> **Symmetric routing**: Inbound traffic goes IGW → Firewall → ALB, and return traffic goes ALB → Firewall → IGW. The firewall sees both directions of every flow.
+
+### Spoke Egress Path (e.g., yum install, SSM)
+1. Spoke EC2 initiates outbound connection → Spoke route table sends 0.0.0.0/0 → TGW
+2. TGW Subnet route table sends 0.0.0.0/0 → **NAT Gateway** (same AZ, source IP translated)
+3. NAT Gateway outbound follows Public Subnet route: 0.0.0.0/0 → **Firewall Endpoint** (same AZ)
+4. Firewall inspects the NAT'd egress traffic → Firewall Subnet routes 0.0.0.0/0 → **IGW**
+5. Return traffic from the internet is steered back through the firewall via the IGW Ingress Route Table
+
+## High Availability Features
+
+- **Multi-AZ Deployment** - Resources distributed across two Availability Zones
+- **AZ-Specific Routing** - Each Public Subnet routes to its same-AZ firewall endpoint; each TGW Subnet routes to its same-AZ NAT Gateway
+- **Per-AZ Firewall Endpoints** - Network Firewall endpoints in each AZ ensure traffic stays within the same AZ
+
+## Deployment Instructions
+
+1. Ensure you have appropriate AWS permissions
+2. (Optional) Provision or import an ACM certificate for the ALB HTTPS listener
+3. Deploy the CloudFormation template:
+   ```bash
+   aws cloudformation create-stack \
+     --stack-name anfw-centralized-ingress-2az \
+     --template-body file://anfw-centralized-ingress-2az-template.yaml \
+     --capabilities CAPABILITY_IAM \
+     --parameters ParameterKey=ALBCertificateArn,ParameterValue=arn:aws:acm:REGION:ACCOUNT:certificate/CERTIFICATE-ID
+   ```
+   Omit the `ALBCertificateArn` parameter to deploy without the HTTPS listener (HTTP only).
+4. Wait for the stack to reach `CREATE_COMPLETE` status
+5. Allow approximately 8-10 minutes after stack completion for EC2 instances to finish UserData execution (installing httpd via the NAT Gateway egress path) and for the Edge ALB target group health checks to pass. You can monitor target health with:
+   ```bash
+   aws elbv2 describe-target-health \
+     --target-group-arn $(aws elbv2 describe-target-groups --names e-http-anfw-centralized-ingress-2az --query 'TargetGroups[0].TargetGroupArn' --output text)
+   ```
+6. Access the Edge ALB DNS name from the stack outputs to test ingress traffic flow
+
+## Important Notes
+
+- **TLS Termination** - TLS is terminated at the Edge ALB using an ACM certificate. All downstream traffic to spoke NLBs and EC2 instances is plaintext HTTP on port 80.
+- **Spoke NLB Static IPs** - Spoke NLBs use static private IPs via SubnetMappings, pre-registered as ALB targets. No manual target registration is needed.
+- **Symmetric Inspection** - The Public Subnet routes 0.0.0.0/0 to the Firewall Endpoint (not the IGW) to ensure return traffic passes through the firewall, avoiding asymmetric routing.
+
+## Cost Considerations
+
+This deployment incurs higher costs compared to single AZ due to:
+- Additional NAT Gateway in second AZ
+- Additional firewall endpoint in second AZ
+- ALB cross-AZ load balancing
+
+## Testing Alternative
+
+For development and testing environments, consider the [Single AZ Deployment](../centralized_ingress_single_az/) which provides the same functionality at lower cost using an NLB instead of an ALB.
+
+## Additional Resources
+
+- [AWS Network Firewall Documentation](https://docs.aws.amazon.com/network-firewall/)
+- [AWS Transit Gateway Documentation](https://docs.aws.amazon.com/transit-gateway/)
+- [Deployment models for AWS Network Firewall Blog](https://aws.amazon.com/blogs/networking-and-content-delivery/deployment-models-for-aws-network-firewall/)

--- a/centralized_architecture/centralized_ingress_two_az/README.md
+++ b/centralized_architecture/centralized_ingress_two_az/README.md
@@ -6,14 +6,14 @@ This template deploys AWS Network Firewall in a centralized ingress inspection a
 
 ## Architecture Overview
 
-This multi-AZ deployment creates a centralized ingress inspection model using an Edge VPC with an internet-facing Application Load Balancer, AWS Network Firewall endpoints in each AZ, and AWS Transit Gateway. Inbound traffic from the internet enters through the Edge VPC Internet Gateway, is steered through the Network Firewall for inspection via an IGW Ingress Route Table, and then reaches the Edge ALB. The ALB terminates TLS and forwards plaintext HTTP to spoke VPC NLBs via Transit Gateway, which distribute traffic to EC2 instances running httpd.
+This multi-AZ deployment creates a centralized ingress inspection model using an Edge VPC with an internet-facing Network Load Balancer, AWS Network Firewall endpoints in each AZ, and AWS Transit Gateway. Inbound traffic from the internet enters through the Edge VPC Internet Gateway, is steered through the Network Firewall for inspection via an IGW Ingress Route Table, and then reaches the Edge NLB. The NLB terminates TLS (optional) and forwards plaintext TCP to spoke VPC NLBs via Transit Gateway, which distribute traffic to EC2 instances running httpd.
 
 ## Resources Created
 
 ### Edge VPC (100.64.0.0/16)
 Centralized VPC for ingress traffic inspection across two AZs:
 - **Firewall Subnets** (100.64.0.16/28, 100.64.0.32/28) - Contains AWS Network Firewall endpoints in each AZ
-- **Public Subnets** (100.64.1.0/24, 100.64.2.0/24) - Contains the internet-facing ALB and NAT Gateways
+- **Public Subnets** (100.64.1.0/24, 100.64.2.0/24) - Contains the internet-facing NLB and NAT Gateways
 - **TGW Subnets** (100.64.0.0/28, 100.64.0.48/28) - Attachment points for Transit Gateway
 - **Internet Gateway** - Entry point for inbound internet traffic
 - **NAT Gateways** (one per AZ) - Provide outbound internet access for spoke EC2 instances (package installation, SSM)
@@ -33,12 +33,12 @@ Two example workload VPCs demonstrating end-to-end ingress traffic flow:
 - SSM VPC endpoints for instance management
 - Security groups allowing ICMP and HTTP from required CIDRs
 
-### Edge ALB
-- Internet-facing Application Load Balancer in the Edge VPC Public Subnets
-- (Optional) HTTPS listener on port 443 that terminates TLS using an ACM certificate and forwards to port 80 (conditional on `ALBCertificateArn` parameter)
-- HTTP listener on port 80
-- Single IP-type target group (port 80, HTTP) with spoke NLB static IPs pre-registered
-- Security group allowing inbound HTTP and HTTPS from 0.0.0.0/0
+### Edge NLB
+- Internet-facing Network Load Balancer in the Edge VPC Public Subnets
+- (Optional) TLS listener on port 443 that terminates TLS using an ACM certificate and forwards to port 80 (conditional on `NLBCertificateArn` parameter)
+- TCP listener on port 80
+- Single IP-type target group (port 80, TCP) with spoke NLB static IPs pre-registered
+- Security group allowing inbound TCP 80 and 443 from 0.0.0.0/0
 
 ### Transit Gateway
 - Central routing hub connecting Edge VPC and spoke VPCs
@@ -52,17 +52,17 @@ Two example workload VPCs demonstrating end-to-end ingress traffic flow:
 1. Client request arrives at the Internet Gateway
 2. IGW Ingress Route Table steers traffic to the Network Firewall endpoint in the same AZ (Public Subnet CIDR → Firewall Endpoint)
 3. Network Firewall inspects the inbound traffic using Suricata stateful rules
-4. Inspected traffic reaches the Edge ALB in the Public Subnet via VPC local route
-5. ALB terminates TLS (if HTTPS) and forwards HTTP to spoke NLB IPs via Transit Gateway (Public Subnet routes 10.0.0.0/8 → TGW)
+4. Inspected traffic reaches the Edge NLB in the Public Subnet via VPC local route
+5. NLB terminates TLS (if HTTPS) and forwards HTTP to spoke NLB IPs via Transit Gateway (Public Subnet routes 10.0.0.0/8 → TGW)
 6. Spoke NLB distributes traffic to EC2 instances running httpd on port 80
 
 ### Ingress Return Path (Application → Internet) — Symmetric
-1. EC2 response returns through the spoke NLB → Transit Gateway → Edge ALB
-2. Edge ALB sends the response to the client; Public Subnet routes 0.0.0.0/0 → **Firewall Endpoint** (same AZ)
+1. EC2 response returns through the spoke NLB → Transit Gateway → Edge NLB
+2. Edge NLB sends the response to the client; Public Subnet routes 0.0.0.0/0 → **Firewall Endpoint** (same AZ)
 3. Network Firewall inspects the return traffic (matching the stateful flow from the inbound path)
 4. Firewall Subnet routes 0.0.0.0/0 → **Internet Gateway**; response exits to the internet
 
-> **Symmetric routing**: Inbound traffic goes IGW → Firewall → ALB, and return traffic goes ALB → Firewall → IGW. The firewall sees both directions of every flow.
+> **Symmetric routing**: Inbound traffic goes IGW → Firewall → NLB, and return traffic goes NLB → Firewall → IGW. The firewall sees both directions of every flow.
 
 ### Spoke Egress Path (e.g., yum install, SSM)
 1. Spoke EC2 initiates outbound connection → Spoke route table sends 0.0.0.0/0 → TGW
@@ -80,28 +80,28 @@ Two example workload VPCs demonstrating end-to-end ingress traffic flow:
 ## Deployment Instructions
 
 1. Ensure you have appropriate AWS permissions
-2. (Optional) Provision or import an ACM certificate for the ALB HTTPS listener - if not provided, the template will skip the HTTPS listener
+2. (Optional) Provision or import an ACM certificate for the NLB TLS listener - if not provided, the template will skip the TLS listener
 3. Deploy the CloudFormation template:
    ```bash
    aws cloudformation create-stack \
      --stack-name anfw-centralized-ingress-2az \
      --template-body file://anfw-centralized-ingress-2az-template.yaml \
      --capabilities CAPABILITY_IAM \
-     --parameters ParameterKey=ALBCertificateArn,ParameterValue=arn:aws:acm:REGION:ACCOUNT:certificate/CERTIFICATE-ID
+     --parameters ParameterKey=NLBCertificateArn,ParameterValue=arn:aws:acm:REGION:ACCOUNT:certificate/CERTIFICATE-ID
    ```
-   Omit the `ALBCertificateArn` parameter to deploy without the HTTPS listener (HTTP only).
+   Omit the `NLBCertificateArn` parameter to deploy without the TLS listener (HTTP only).
 4. Wait for the stack to reach `CREATE_COMPLETE` status
-5. Allow approximately 8-10 minutes after stack completion for EC2 instances to finish UserData execution (installing httpd via the NAT Gateway egress path) and for the Edge ALB target group health checks to pass. You can monitor target health with:
+5. Allow approximately 8-10 minutes after stack completion for EC2 instances to finish UserData execution (installing httpd via the NAT Gateway egress path) and for the Edge NLB target group health checks to pass. You can monitor target health with:
    ```bash
    aws elbv2 describe-target-health \
      --target-group-arn $(aws elbv2 describe-target-groups --names e-http-anfw-centralized-ingress-2az --query 'TargetGroups[0].TargetGroupArn' --output text)
    ```
-6. Access the Edge ALB DNS name from the stack outputs to test ingress traffic flow
+6. Access the Edge NLB DNS name from the stack outputs to test ingress traffic flow
 
 ## Important Notes
 
-- **(Optional) TLS Termination** - TLS is terminated at the Edge ALB using an ACM certificate. All downstream traffic to spoke NLBs and EC2 instances is plaintext HTTP on port 80.
-- **Spoke NLB Static IPs** - Spoke NLBs use static private IPs via SubnetMappings, pre-registered as ALB targets. No manual target registration is needed.
+- **(Optional) TLS Termination** - TLS is terminated at the Edge NLB using an ACM certificate. All downstream traffic to spoke NLBs and EC2 instances is plaintext HTTP on port 80.
+- **Spoke NLB Static IPs** - Spoke NLBs use static private IPs via SubnetMappings, pre-registered as Edge NLB targets. No manual target registration is needed.
 - **Symmetric Inspection** - The Public Subnet routes 0.0.0.0/0 to the Firewall Endpoint (not the IGW) to ensure return traffic passes through the firewall, avoiding asymmetric routing.
 
 ## Enabling the Allow-List Rule Group
@@ -128,11 +128,11 @@ The allow-list rules will:
 This deployment incurs higher costs compared to single AZ due to:
 - Additional NAT Gateway in second AZ
 - Additional firewall endpoint in second AZ
-- ALB cross-AZ load balancing
+- NLB cross-AZ load balancing
 
 ## Testing Alternative
 
-For development and testing environments, consider the [Single AZ Deployment](../centralized_ingress_single_az/) which provides the same functionality at lower cost using an NLB instead of an ALB.
+For development and testing environments, consider the [Single AZ Deployment](../centralized_ingress_single_az/) which provides the same functionality at lower cost at lower cost.
 
 ## Additional Resources
 

--- a/centralized_architecture/centralized_ingress_two_az/README.md
+++ b/centralized_architecture/centralized_ingress_two_az/README.md
@@ -35,7 +35,7 @@ Two example workload VPCs demonstrating end-to-end ingress traffic flow:
 
 ### Edge ALB
 - Internet-facing Application Load Balancer in the Edge VPC Public Subnets
-- HTTPS listener on port 443 that terminates TLS using an ACM certificate and forwards to port 80 (conditional on `ALBCertificateArn` parameter)
+- (Optional) HTTPS listener on port 443 that terminates TLS using an ACM certificate and forwards to port 80 (conditional on `ALBCertificateArn` parameter)
 - HTTP listener on port 80
 - Single IP-type target group (port 80, HTTP) with spoke NLB static IPs pre-registered
 - Security group allowing inbound HTTP and HTTPS from 0.0.0.0/0
@@ -80,7 +80,7 @@ Two example workload VPCs demonstrating end-to-end ingress traffic flow:
 ## Deployment Instructions
 
 1. Ensure you have appropriate AWS permissions
-2. (Optional) Provision or import an ACM certificate for the ALB HTTPS listener
+2. (Optional) Provision or import an ACM certificate for the ALB HTTPS listener - if not provided, the template will skip the HTTPS listener
 3. Deploy the CloudFormation template:
    ```bash
    aws cloudformation create-stack \
@@ -100,9 +100,28 @@ Two example workload VPCs demonstrating end-to-end ingress traffic flow:
 
 ## Important Notes
 
-- **TLS Termination** - TLS is terminated at the Edge ALB using an ACM certificate. All downstream traffic to spoke NLBs and EC2 instances is plaintext HTTP on port 80.
+- **(Optional) TLS Termination** - TLS is terminated at the Edge ALB using an ACM certificate. All downstream traffic to spoke NLBs and EC2 instances is plaintext HTTP on port 80.
 - **Spoke NLB Static IPs** - Spoke NLBs use static private IPs via SubnetMappings, pre-registered as ALB targets. No manual target registration is needed.
 - **Symmetric Inspection** - The Public Subnet routes 0.0.0.0/0 to the Firewall Endpoint (not the IGW) to ensure return traffic passes through the firewall, avoiding asymmetric routing.
+
+## Enabling the Allow-List Rule Group
+
+By default, only the log-only rule group is active — it alerts on inbound traffic patterns without blocking anything. The template also creates a comprehensive allow-list rule group (`IngressAllowListRuleGroup`) that is defined but not referenced in the firewall policy.
+
+When you're ready to move beyond log-only mode and enforce ingress filtering:
+
+1. Open the [Network Firewall console](https://console.aws.amazon.com/vpc/home#NetworkFirewallPolicies) and select the `ingress-firewall-policy-<stack-name>` policy
+2. Under **Stateful rule group references**, click **Add rule group** and select `ingress-allow-list-<stack-name>`
+3. Set its priority to a value higher than the log-only group (e.g., 100 if log-only is at 50) so alerts fire before enforcement
+4. Save the policy — the firewall endpoints will sync within a few minutes
+
+The allow-list rules will:
+- **Pass** inbound HTTP (port 80) and HTTPS (port 443) to HOME_NET
+- **Pass** established return traffic from HOME_NET
+- **Alert** on traffic from RU/CN geolocations
+- **Drop** all other inbound TCP, UDP, ICMP, and IP traffic
+
+> **Note:** The log-only group fires first (lower priority number), so you retain full alert visibility even after enabling enforcement. To revert to log-only mode, remove the allow-list reference from the policy. If you added the allow-list via the console (outside CloudFormation), remember to remove it before deleting the stack to avoid delete failures.
 
 ## Cost Considerations
 

--- a/centralized_architecture/centralized_ingress_two_az/anfw-centralized-ingress-2az-template.yaml
+++ b/centralized_architecture/centralized_ingress_two_az/anfw-centralized-ingress-2az-template.yaml
@@ -189,7 +189,7 @@ Resources:
   SubnetASecGroup:
     Type: AWS::EC2::SecurityGroup
     Properties:
-      GroupDescription: "ICMP acess from 10.0.0.0/8 and inspection VPC, HTTP/HTTPS from inspection VPC and spoke VPC"
+      GroupDescription: "ICMP acess from 10.0.0.0/8 and inspection VPC, HTTP from inspection VPC and spoke VPC"
       GroupName: !Sub "spoke-a-sec-group-${AWS::StackName}"
       VpcId: !Ref SpokeVPCA
       SecurityGroupIngress:
@@ -209,20 +209,10 @@ Resources:
           FromPort: 80
           ToPort: 80
         - IpProtocol: tcp
-          CidrIp: 100.64.0.0/16
-          Description: "Allow HTTPS from Edge VPC (NLB traffic)"
-          FromPort: 443
-          ToPort: 443
-        - IpProtocol: tcp
           CidrIp: 10.1.0.0/16
           Description: "Allow HTTP from Spoke A VPC (NLB health checks)"
           FromPort: 80
           ToPort: 80
-        - IpProtocol: tcp
-          CidrIp: 10.1.0.0/16
-          Description: "Allow HTTPS from Spoke A VPC (NLB health checks)"
-          FromPort: 443
-          ToPort: 443
 
   EC2SubnetA:
     Type: 'AWS::EC2::Instance'
@@ -242,13 +232,7 @@ Resources:
           #!/bin/bash
           # Wait for internet connectivity (egress path via NAT GW may take time to converge)
           for i in $(seq 1 30); do curl -s --max-time 5 https://amazonlinux-2-repos-us-east-1.s3.dualstack.us-east-1.amazonaws.com && break || sleep 10; done
-          yum install -y httpd mod_ssl
-          openssl req -x509 -nodes -days 365 -newkey rsa:2048 \
-            -keyout /etc/pki/tls/private/localhost.key \
-            -out /etc/pki/tls/certs/localhost.crt \
-            -subj "/CN=localhost"
-          # Harden TLS: disable weak protocols and ciphers
-          printf '%s\n' 'SSLProtocol -all +TLSv1.2' 'SSLCipherSuite ECDHE-ECDSA-AES128-GCM-SHA256:ECDHE-RSA-AES128-GCM-SHA256:ECDHE-ECDSA-AES256-GCM-SHA384:ECDHE-RSA-AES256-GCM-SHA384' 'SSLHonorCipherOrder on' > /etc/httpd/conf.d/ssl-hardening.conf
+          yum install -y httpd
           systemctl start httpd
           systemctl enable httpd
           echo "<html><body><h1>Spoke A - ${AvailabilityZoneSelection1}</h1></body></html>" > /var/www/html/index.html
@@ -273,12 +257,7 @@ Resources:
         Fn::Base64: !Sub |
           #!/bin/bash
           for i in $(seq 1 30); do curl -s --max-time 5 https://amazonlinux-2-repos-us-east-1.s3.dualstack.us-east-1.amazonaws.com && break || sleep 10; done
-          yum install -y httpd mod_ssl
-          openssl req -x509 -nodes -days 365 -newkey rsa:2048 \
-            -keyout /etc/pki/tls/private/localhost.key \
-            -out /etc/pki/tls/certs/localhost.crt \
-            -subj "/CN=localhost"
-          printf '%s\n' 'SSLProtocol -all +TLSv1.2' 'SSLCipherSuite ECDHE-ECDSA-AES128-GCM-SHA256:ECDHE-RSA-AES128-GCM-SHA256:ECDHE-ECDSA-AES256-GCM-SHA384:ECDHE-RSA-AES256-GCM-SHA384' 'SSLHonorCipherOrder on' > /etc/httpd/conf.d/ssl-hardening.conf
+          yum install -y httpd
           systemctl start httpd
           systemctl enable httpd
           echo "<html><body><h1>Spoke A - ${AvailabilityZoneSelection2}</h1></body></html>" > /var/www/html/index.html
@@ -428,7 +407,7 @@ Resources:
   SubnetBSecGroup:
     Type: AWS::EC2::SecurityGroup
     Properties:
-      GroupDescription: "ICMP acess from 10.0.0.0/8 and inspection VPC, HTTP/HTTPS from inspection VPC and spoke VPC"
+      GroupDescription: "ICMP acess from 10.0.0.0/8 and inspection VPC, HTTP from inspection VPC and spoke VPC"
       GroupName: !Sub "spoke-b-sec-group-${AWS::StackName}"
       VpcId: !Ref SpokeVPCB
       SecurityGroupIngress:
@@ -448,20 +427,10 @@ Resources:
           FromPort: 80
           ToPort: 80
         - IpProtocol: tcp
-          CidrIp: 100.64.0.0/16
-          Description: "Allow HTTPS from Edge VPC (NLB traffic)"
-          FromPort: 443
-          ToPort: 443
-        - IpProtocol: tcp
           CidrIp: 10.2.0.0/16
           Description: "Allow HTTP from Spoke B VPC (NLB health checks)"
           FromPort: 80
           ToPort: 80
-        - IpProtocol: tcp
-          CidrIp: 10.2.0.0/16
-          Description: "Allow HTTPS from Spoke B VPC (NLB health checks)"
-          FromPort: 443
-          ToPort: 443
 
   EC2SubnetB:
     Type: 'AWS::EC2::Instance'
@@ -480,12 +449,7 @@ Resources:
         Fn::Base64: !Sub |
           #!/bin/bash
           for i in $(seq 1 30); do curl -s --max-time 5 https://amazonlinux-2-repos-us-east-1.s3.dualstack.us-east-1.amazonaws.com && break || sleep 10; done
-          yum install -y httpd mod_ssl
-          openssl req -x509 -nodes -days 365 -newkey rsa:2048 \
-            -keyout /etc/pki/tls/private/localhost.key \
-            -out /etc/pki/tls/certs/localhost.crt \
-            -subj "/CN=localhost"
-          printf '%s\n' 'SSLProtocol -all +TLSv1.2' 'SSLCipherSuite ECDHE-ECDSA-AES128-GCM-SHA256:ECDHE-RSA-AES128-GCM-SHA256:ECDHE-ECDSA-AES256-GCM-SHA384:ECDHE-RSA-AES256-GCM-SHA384' 'SSLHonorCipherOrder on' > /etc/httpd/conf.d/ssl-hardening.conf
+          yum install -y httpd
           systemctl start httpd
           systemctl enable httpd
           echo "<html><body><h1>Spoke B - ${AvailabilityZoneSelection1}</h1></body></html>" > /var/www/html/index.html
@@ -510,12 +474,7 @@ Resources:
         Fn::Base64: !Sub |
           #!/bin/bash
           for i in $(seq 1 30); do curl -s --max-time 5 https://amazonlinux-2-repos-us-east-1.s3.dualstack.us-east-1.amazonaws.com && break || sleep 10; done
-          yum install -y httpd mod_ssl
-          openssl req -x509 -nodes -days 365 -newkey rsa:2048 \
-            -keyout /etc/pki/tls/private/localhost.key \
-            -out /etc/pki/tls/certs/localhost.crt \
-            -subj "/CN=localhost"
-          printf '%s\n' 'SSLProtocol -all +TLSv1.2' 'SSLCipherSuite ECDHE-ECDSA-AES128-GCM-SHA256:ECDHE-RSA-AES128-GCM-SHA256:ECDHE-ECDSA-AES256-GCM-SHA384:ECDHE-RSA-AES256-GCM-SHA384' 'SSLHonorCipherOrder on' > /etc/httpd/conf.d/ssl-hardening.conf
+          yum install -y httpd
           systemctl start httpd
           systemctl enable httpd
           echo "<html><body><h1>Spoke B - ${AvailabilityZoneSelection2}</h1></body></html>" > /var/www/html/index.html
@@ -565,31 +524,6 @@ Resources:
         - Type: forward
           TargetGroupArn: !Ref SpokeANLBTargetGroupHTTP
 
-  SpokeANLBTargetGroupHTTPS:
-    Type: AWS::ElasticLoadBalancingV2::TargetGroup
-    Properties:
-      Name: !Sub "sa-htps-${AWS::StackName}"
-      Port: 443
-      Protocol: TCP
-      TargetType: instance
-      VpcId: !Ref SpokeVPCA
-      Targets:
-        - Id: !Ref EC2SubnetA
-        - Id: !Ref EC2SubnetA2
-      Tags:
-        - Key: Name
-          Value: !Sub "spoke-a-nlb-tg-https-${AWS::StackName}"
-
-  SpokeANLBListenerHTTPS:
-    Type: AWS::ElasticLoadBalancingV2::Listener
-    Properties:
-      LoadBalancerArn: !Ref SpokeANLB
-      Port: 443
-      Protocol: TCP
-      DefaultActions:
-        - Type: forward
-          TargetGroupArn: !Ref SpokeANLBTargetGroupHTTPS
-
   SpokeBNLB:
     Type: AWS::ElasticLoadBalancingV2::LoadBalancer
     Properties:
@@ -629,31 +563,6 @@ Resources:
       DefaultActions:
         - Type: forward
           TargetGroupArn: !Ref SpokeBNLBTargetGroupHTTP
-
-  SpokeBNLBTargetGroupHTTPS:
-    Type: AWS::ElasticLoadBalancingV2::TargetGroup
-    Properties:
-      Name: !Sub "sb-htps-${AWS::StackName}"
-      Port: 443
-      Protocol: TCP
-      TargetType: instance
-      VpcId: !Ref SpokeVPCB
-      Targets:
-        - Id: !Ref EC2SubnetB
-        - Id: !Ref EC2SubnetB2
-      Tags:
-        - Key: Name
-          Value: !Sub "spoke-b-nlb-tg-https-${AWS::StackName}"
-
-  SpokeBNLBListenerHTTPS:
-    Type: AWS::ElasticLoadBalancingV2::Listener
-    Properties:
-      LoadBalancerArn: !Ref SpokeBNLB
-      Port: 443
-      Protocol: TCP
-      DefaultActions:
-        - Type: forward
-          TargetGroupArn: !Ref SpokeBNLBTargetGroupHTTPS
 
 
 # Edge VPC
@@ -833,7 +742,8 @@ Resources:
         - Key: Name
           Value: !Sub "edge-alb-${AWS::StackName}"
 
-  # IP-type target groups targeting all spoke NLB static IPs via TGW
+  # IP-type target group targeting all spoke NLB static IPs via TGW (port 80 only)
+  # TLS is terminated at the ALB; all downstream traffic is plaintext HTTP
   EdgeALBTargetGroupHTTP:
     Type: AWS::ElasticLoadBalancingV2::TargetGroup
     Properties:
@@ -855,28 +765,6 @@ Resources:
         - Key: Name
           Value: !Sub "e-tg-http-${AWS::StackName}"
 
-  EdgeALBTargetGroupHTTPS:
-    Type: AWS::ElasticLoadBalancingV2::TargetGroup
-    Condition: HasALBCertificate
-    Properties:
-      Name: !Sub "e-htps-${AWS::StackName}"
-      Port: 443
-      Protocol: HTTPS
-      TargetType: ip
-      VpcId: !Ref EdgeVPC
-      Targets:
-        - Id: "10.1.1.10"
-          AvailabilityZone: "all"
-        - Id: "10.1.2.10"
-          AvailabilityZone: "all"
-        - Id: "10.2.1.10"
-          AvailabilityZone: "all"
-        - Id: "10.2.2.10"
-          AvailabilityZone: "all"
-      Tags:
-        - Key: Name
-          Value: !Sub "e-tg-https-${AWS::StackName}"
-
   EdgeALBListenerHTTP:
     Type: AWS::ElasticLoadBalancingV2::Listener
     Properties:
@@ -887,6 +775,7 @@ Resources:
         - Type: forward
           TargetGroupArn: !Ref EdgeALBTargetGroupHTTP
 
+  # HTTPS listener terminates TLS using ACM certificate and forwards to port 80 HTTP target group
   EdgeALBListenerHTTPS:
     Type: AWS::ElasticLoadBalancingV2::Listener
     Condition: HasALBCertificate
@@ -896,9 +785,10 @@ Resources:
       Protocol: HTTPS
       Certificates:
         - CertificateArn: !Ref ALBCertificateArn
+      SslPolicy: ELBSecurityPolicy-TLS13-1-2-2021-06
       DefaultActions:
         - Type: forward
-          TargetGroupArn: !Ref EdgeALBTargetGroupHTTPS
+          TargetGroupArn: !Ref EdgeALBTargetGroupHTTP
 
 
 # Network Firewall
@@ -990,6 +880,7 @@ Resources:
             HOME_NET:
               Definition:
                 - 10.0.0.0/8
+                - 100.64.0.0/16
                 - 172.16.0.0/12
                 - 192.168.0.0/16
       Tags:
@@ -1559,3 +1450,69 @@ Outputs:
     Value: !Ref EdgeALBSecurityGroup
     Export:
       Name: !Sub "${AWS::StackName}-EdgeALBSecGroup"
+
+  EdgeNATGateway1Id:
+    Description: Edge NAT Gateway ID (AZ1)
+    Value: !Ref EdgeNATGateway1
+    Export:
+      Name: !Sub "${AWS::StackName}-EdgeNATGateway1"
+
+  EdgeNATGateway2Id:
+    Description: Edge NAT Gateway ID (AZ2)
+    Value: !Ref EdgeNATGateway2
+    Export:
+      Name: !Sub "${AWS::StackName}-EdgeNATGateway2"
+
+  EdgeNATEIP1AllocationId:
+    Description: Edge NAT Gateway Elastic IP (AZ1)
+    Value: !Ref EdgeNATEIP1
+    Export:
+      Name: !Sub "${AWS::StackName}-EdgeNATEIP1"
+
+  EdgeNATEIP2AllocationId:
+    Description: Edge NAT Gateway Elastic IP (AZ2)
+    Value: !Ref EdgeNATEIP2
+    Export:
+      Name: !Sub "${AWS::StackName}-EdgeNATEIP2"
+
+  SpokeASecurityGroupId:
+    Description: Spoke A Security Group ID
+    Value: !Ref SubnetASecGroup
+    Export:
+      Name: !Sub "${AWS::StackName}-SpokeASecGroup"
+
+  SpokeBSecurityGroupId:
+    Description: Spoke B Security Group ID
+    Value: !Ref SubnetBSecGroup
+    Export:
+      Name: !Sub "${AWS::StackName}-SpokeBSecGroup"
+
+  SpokeANLBDNSName:
+    Description: "Spoke A NLB DNS Name (static IPs: 10.1.1.10, 10.1.2.10)"
+    Value: !GetAtt SpokeANLB.DNSName
+    Export:
+      Name: !Sub "${AWS::StackName}-SpokeANLBDNSName"
+
+  SpokeBNLBDNSName:
+    Description: "Spoke B NLB DNS Name (static IPs: 10.2.1.10, 10.2.2.10)"
+    Value: !GetAtt SpokeBNLB.DNSName
+    Export:
+      Name: !Sub "${AWS::StackName}-SpokeBNLBDNSName"
+
+  SpokeRouteTableId:
+    Description: Spoke TGW Route Table ID
+    Value: !Ref SpokeRouteTable
+    Export:
+      Name: !Sub "${AWS::StackName}-SpokeRouteTable"
+
+  InspectionRouteTableId:
+    Description: Inspection TGW Route Table ID
+    Value: !Ref InspectionRouteTable
+    Export:
+      Name: !Sub "${AWS::StackName}-InspectionRouteTable"
+
+  EdgeVPCAttachmentId:
+    Description: Edge VPC TGW Attachment ID
+    Value: !Ref AttachEdgeVPC
+    Export:
+      Name: !Sub "${AWS::StackName}-EdgeVPCAttachment"

--- a/centralized_architecture/centralized_ingress_two_az/anfw-centralized-ingress-2az-template.yaml
+++ b/centralized_architecture/centralized_ingress_two_az/anfw-centralized-ingress-2az-template.yaml
@@ -8,7 +8,7 @@
 #CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 AWSTemplateFormatVersion: "2010-09-09"
-Description: "AWS Network Firewall Demo - Centralized ingress inspection with Edge VPC, Network Firewall, ALB, Transit Gateway, and spoke VPCs with NLBs (two AZ deployment)"
+Description: "AWS Network Firewall Demo - Centralized ingress inspection with Edge VPC, Network Firewall, NLB, Transit Gateway, and spoke VPCs with NLBs (two AZ deployment)"
 
 Metadata:
   "AWS::CloudFormation::Interface":
@@ -18,7 +18,7 @@ Metadata:
         Parameters:
           - AvailabilityZoneSelection1
           - AvailabilityZoneSelection2
-          - ALBCertificateArn
+          - NLBCertificateArn
       - Label:
           default: "EC2 Parameters"
         Parameters:
@@ -34,8 +34,8 @@ Parameters:
     Type: AWS::EC2::AvailabilityZone::Name
     Default: us-east-1b
 
-  ALBCertificateArn:
-    Description: ACM Certificate ARN for the ALB HTTPS listener (leave empty to skip HTTPS listener)
+  NLBCertificateArn:
+    Description: ACM Certificate ARN for the Edge NLB TLS listener (leave empty to skip TLS listener)
     Type: String
     Default: ""
 
@@ -45,7 +45,7 @@ Parameters:
     Default: '/aws/service/ami-amazon-linux-latest/amzn2-ami-hvm-x86_64-gp2'
 
 Conditions:
-  HasALBCertificate: !Not [!Equals [!Ref ALBCertificateArn, ""]]
+  HasNLBCertificate: !Not [!Equals [!Ref NLBCertificateArn, ""]]
 
 Resources:
 # Spoke VPC A
@@ -60,14 +60,12 @@ Resources:
         - Key: Name
           Value: !Sub "spoke-a-${AWS::StackName}"
 
-  SubnetAWorkload:
+  SubnetAWorkload1:
     Type: AWS::EC2::Subnet
     Properties:
-      VpcId:
-        Ref: SpokeVPCA
+      VpcId: !Ref SpokeVPCA
       CidrBlock: "10.1.1.0/24"
-      AvailabilityZone: 
-        Ref: AvailabilityZoneSelection1
+      AvailabilityZone: !Ref AvailabilityZoneSelection1
       MapPublicIpOnLaunch: false
       Tags:
         - Key: Name
@@ -76,24 +74,20 @@ Resources:
   SubnetAWorkload2:
     Type: AWS::EC2::Subnet
     Properties:
-      VpcId:
-        Ref: SpokeVPCA
+      VpcId: !Ref SpokeVPCA
       CidrBlock: "10.1.2.0/24"
-      AvailabilityZone: 
-        Ref: AvailabilityZoneSelection2
+      AvailabilityZone: !Ref AvailabilityZoneSelection2
       MapPublicIpOnLaunch: false
       Tags:
         - Key: Name
           Value: !Sub "spoke-a-workload-2-${AWS::StackName}"
 
-  SubnetATGW:
+  SubnetATGW1:
     Type: AWS::EC2::Subnet
     Properties:
-      VpcId:
-        Ref: SpokeVPCA
+      VpcId: !Ref SpokeVPCA
       CidrBlock: "10.1.0.0/28"
-      AvailabilityZone:
-        Ref: AvailabilityZoneSelection1
+      AvailabilityZone: !Ref AvailabilityZoneSelection1
       MapPublicIpOnLaunch: false
       Tags:
         - Key: Name
@@ -102,11 +96,9 @@ Resources:
   SubnetATGW2:
     Type: AWS::EC2::Subnet
     Properties:
-      VpcId:
-        Ref: SpokeVPCA
+      VpcId: !Ref SpokeVPCA
       CidrBlock: "10.1.0.16/28"
-      AvailabilityZone:
-        Ref: AvailabilityZoneSelection2
+      AvailabilityZone: !Ref AvailabilityZoneSelection2
       MapPublicIpOnLaunch: false
       Tags:
         - Key: Name
@@ -123,52 +115,53 @@ Resources:
           ToPort: 443
           CidrIp: 10.1.0.0/16
           Description: "Allow HTTPS traffic from Spoke A VPC for SSM access"
+
   SpokeASSMEndpoint:
     Type: AWS::EC2::VPCEndpoint
-    Properties: 
+    Properties:
         PrivateDnsEnabled: true
-        SecurityGroupIds: 
+        SecurityGroupIds:
           - !Ref SpokeAEndpointSecurityGroup
         ServiceName: !Sub "com.amazonaws.${AWS::Region}.ssm"
-        SubnetIds: 
-          - !Ref SubnetAWorkload
+        SubnetIds:
+          - !Ref SubnetAWorkload1
           - !Ref SubnetAWorkload2
         VpcEndpointType: Interface
         VpcId: !Ref SpokeVPCA
 
   SpokeAEC2MessagesEndpoint:
     Type: AWS::EC2::VPCEndpoint
-    Properties: 
+    Properties:
         PrivateDnsEnabled: true
-        SecurityGroupIds: 
+        SecurityGroupIds:
           - !Ref SpokeAEndpointSecurityGroup
         ServiceName: !Sub "com.amazonaws.${AWS::Region}.ec2messages"
-        SubnetIds: 
-          - !Ref SubnetAWorkload
+        SubnetIds:
+          - !Ref SubnetAWorkload1
           - !Ref SubnetAWorkload2
         VpcEndpointType: Interface
         VpcId: !Ref SpokeVPCA
 
   SpokeASSMMessagesEndpoint:
     Type: AWS::EC2::VPCEndpoint
-    Properties: 
+    Properties:
         PrivateDnsEnabled: true
-        SecurityGroupIds: 
+        SecurityGroupIds:
           - !Ref SpokeAEndpointSecurityGroup
         ServiceName: !Sub "com.amazonaws.${AWS::Region}.ssmmessages"
-        SubnetIds: 
-          - !Ref SubnetAWorkload
+        SubnetIds:
+          - !Ref SubnetAWorkload1
           - !Ref SubnetAWorkload2
         VpcEndpointType: Interface
         VpcId: !Ref SpokeVPCA
- 
+
   SubnetARole:
     Type: AWS::IAM::Role
     Properties:
       RoleName: !Sub "subnet-a-role-${AWS::StackName}"
       Path: "/"
       ManagedPolicyArns:
-        - "arn:aws:iam::aws:policy/service-role/AmazonEC2RoleforSSM"
+        - "arn:aws:iam::aws:policy/AmazonSSMManagedInstanceCore"
       AssumeRolePolicyDocument:
         Version: "2012-10-17"
         Statement:
@@ -185,11 +178,11 @@ Resources:
       Path: "/"
       Roles:
         - !Ref SubnetARole
-        
+
   SubnetASecGroup:
     Type: AWS::EC2::SecurityGroup
     Properties:
-      GroupDescription: "ICMP acess from 10.0.0.0/8 and inspection VPC, HTTP from inspection VPC and spoke VPC"
+      GroupDescription: "ICMP access from 10.0.0.0/8 and inspection VPC, HTTP from inspection VPC and spoke VPC"
       GroupName: !Sub "spoke-a-sec-group-${AWS::StackName}"
       VpcId: !Ref SpokeVPCA
       SecurityGroupIngress:
@@ -214,15 +207,15 @@ Resources:
           FromPort: 80
           ToPort: 80
 
-  EC2SubnetA:
+  EC2SubnetA1:
     Type: 'AWS::EC2::Instance'
     DependsOn:
       - EdgeFirewallDefaultRoute1
-      - SubnetAWorkloadDefaultRoute
+      - SubnetAWorkload1DefaultRoute
       - SpokeDefaultRoute
     Properties:
       ImageId: !Ref LatestAmiId
-      SubnetId: !Ref SubnetAWorkload
+      SubnetId: !Ref SubnetAWorkload1
       InstanceType: t2.micro
       SecurityGroupIds:
         - !Ref SubnetASecGroup
@@ -231,7 +224,7 @@ Resources:
         Fn::Base64: !Sub |
           #!/bin/bash
           # Wait for internet connectivity (egress path via NAT GW may take time to converge)
-          for i in $(seq 1 30); do curl -s --max-time 5 https://amazonlinux-2-repos-us-east-1.s3.dualstack.us-east-1.amazonaws.com && break || sleep 10; done
+          for i in $(seq 1 30); do curl -s --max-time 5 https://amazonlinux-2-repos-${AWS::Region}.s3.dualstack.${AWS::Region}.amazonaws.com && break || sleep 10; done
           yum install -y httpd
           systemctl start httpd
           systemctl enable httpd
@@ -256,7 +249,7 @@ Resources:
       UserData:
         Fn::Base64: !Sub |
           #!/bin/bash
-          for i in $(seq 1 30); do curl -s --max-time 5 https://amazonlinux-2-repos-us-east-1.s3.dualstack.us-east-1.amazonaws.com && break || sleep 10; done
+          for i in $(seq 1 30); do curl -s --max-time 5 https://amazonlinux-2-repos-${AWS::Region}.s3.dualstack.${AWS::Region}.amazonaws.com && break || sleep 10; done
           yum install -y httpd
           systemctl start httpd
           systemctl enable httpd
@@ -265,7 +258,6 @@ Resources:
         - Key: Name
           Value: !Sub "spoke-a-2-${AWS::StackName}"
 
-      
 # Spoke VPC B
   SpokeVPCB:
     Type: AWS::EC2::VPC
@@ -278,14 +270,12 @@ Resources:
         - Key: Name
           Value: !Sub "spoke-b-${AWS::StackName}"
 
-  SubnetBWorkload:
+  SubnetBWorkload1:
     Type: AWS::EC2::Subnet
     Properties:
-      VpcId:
-        Ref: SpokeVPCB
+      VpcId: !Ref SpokeVPCB
       CidrBlock: "10.2.1.0/24"
-      AvailabilityZone:
-        Ref: AvailabilityZoneSelection1
+      AvailabilityZone: !Ref AvailabilityZoneSelection1
       MapPublicIpOnLaunch: false
       Tags:
         - Key: Name
@@ -294,24 +284,20 @@ Resources:
   SubnetBWorkload2:
     Type: AWS::EC2::Subnet
     Properties:
-      VpcId:
-        Ref: SpokeVPCB
+      VpcId: !Ref SpokeVPCB
       CidrBlock: "10.2.2.0/24"
-      AvailabilityZone:
-        Ref: AvailabilityZoneSelection2
+      AvailabilityZone: !Ref AvailabilityZoneSelection2
       MapPublicIpOnLaunch: false
       Tags:
         - Key: Name
           Value: !Sub "spoke-b-workload-2-${AWS::StackName}"
 
-  SubnetBTGW:
+  SubnetBTGW1:
     Type: AWS::EC2::Subnet
     Properties:
-      VpcId:
-        Ref: SpokeVPCB
+      VpcId: !Ref SpokeVPCB
       CidrBlock: "10.2.0.0/28"
-      AvailabilityZone:
-        Ref: AvailabilityZoneSelection1
+      AvailabilityZone: !Ref AvailabilityZoneSelection1
       MapPublicIpOnLaunch: false
       Tags:
         - Key: Name
@@ -320,11 +306,9 @@ Resources:
   SubnetBTGW2:
     Type: AWS::EC2::Subnet
     Properties:
-      VpcId:
-        Ref: SpokeVPCB
+      VpcId: !Ref SpokeVPCB
       CidrBlock: "10.2.0.16/28"
-      AvailabilityZone:
-        Ref: AvailabilityZoneSelection2
+      AvailabilityZone: !Ref AvailabilityZoneSelection2
       MapPublicIpOnLaunch: false
       Tags:
         - Key: Name
@@ -341,41 +325,42 @@ Resources:
           ToPort: 443
           CidrIp: 10.2.0.0/16
           Description: "Allow HTTPS traffic from Spoke B VPC for SSM access"
+
   SpokeBSSMEndpoint:
     Type: AWS::EC2::VPCEndpoint
-    Properties: 
+    Properties:
         PrivateDnsEnabled: true
-        SecurityGroupIds: 
+        SecurityGroupIds:
           - !Ref SpokeBEndpointSecurityGroup
         ServiceName: !Sub "com.amazonaws.${AWS::Region}.ssm"
-        SubnetIds: 
-          - !Ref SubnetBWorkload
+        SubnetIds:
+          - !Ref SubnetBWorkload1
           - !Ref SubnetBWorkload2
         VpcEndpointType: Interface
         VpcId: !Ref SpokeVPCB
 
   SpokeBEC2MessagesEndpoint:
     Type: AWS::EC2::VPCEndpoint
-    Properties: 
+    Properties:
         PrivateDnsEnabled: true
-        SecurityGroupIds: 
+        SecurityGroupIds:
           - !Ref SpokeBEndpointSecurityGroup
         ServiceName: !Sub "com.amazonaws.${AWS::Region}.ec2messages"
-        SubnetIds: 
-          - !Ref SubnetBWorkload
+        SubnetIds:
+          - !Ref SubnetBWorkload1
           - !Ref SubnetBWorkload2
         VpcEndpointType: Interface
         VpcId: !Ref SpokeVPCB
 
   SpokeBSSMMessagesEndpoint:
     Type: AWS::EC2::VPCEndpoint
-    Properties: 
+    Properties:
         PrivateDnsEnabled: true
-        SecurityGroupIds: 
+        SecurityGroupIds:
           - !Ref SpokeBEndpointSecurityGroup
         ServiceName: !Sub "com.amazonaws.${AWS::Region}.ssmmessages"
-        SubnetIds: 
-          - !Ref SubnetBWorkload
+        SubnetIds:
+          - !Ref SubnetBWorkload1
           - !Ref SubnetBWorkload2
         VpcEndpointType: Interface
         VpcId: !Ref SpokeVPCB
@@ -386,7 +371,7 @@ Resources:
       RoleName: !Sub "subnet-b-role-${AWS::StackName}"
       Path: "/"
       ManagedPolicyArns:
-        - "arn:aws:iam::aws:policy/service-role/AmazonEC2RoleforSSM"
+        - "arn:aws:iam::aws:policy/AmazonSSMManagedInstanceCore"
       AssumeRolePolicyDocument:
         Version: "2012-10-17"
         Statement:
@@ -403,11 +388,11 @@ Resources:
       Path: "/"
       Roles:
         - !Ref SubnetBRole
-        
+
   SubnetBSecGroup:
     Type: AWS::EC2::SecurityGroup
     Properties:
-      GroupDescription: "ICMP acess from 10.0.0.0/8 and inspection VPC, HTTP from inspection VPC and spoke VPC"
+      GroupDescription: "ICMP access from 10.0.0.0/8 and inspection VPC, HTTP from inspection VPC and spoke VPC"
       GroupName: !Sub "spoke-b-sec-group-${AWS::StackName}"
       VpcId: !Ref SpokeVPCB
       SecurityGroupIngress:
@@ -432,15 +417,15 @@ Resources:
           FromPort: 80
           ToPort: 80
 
-  EC2SubnetB:
+  EC2SubnetB1:
     Type: 'AWS::EC2::Instance'
     DependsOn:
       - EdgeFirewallDefaultRoute1
-      - SubnetBWorkloadDefaultRoute
+      - SubnetBWorkload1DefaultRoute
       - SpokeDefaultRoute
     Properties:
       ImageId: !Ref LatestAmiId
-      SubnetId: !Ref SubnetBWorkload
+      SubnetId: !Ref SubnetBWorkload1
       InstanceType: t2.micro
       SecurityGroupIds:
         - !Ref SubnetBSecGroup
@@ -448,7 +433,7 @@ Resources:
       UserData:
         Fn::Base64: !Sub |
           #!/bin/bash
-          for i in $(seq 1 30); do curl -s --max-time 5 https://amazonlinux-2-repos-us-east-1.s3.dualstack.us-east-1.amazonaws.com && break || sleep 10; done
+          for i in $(seq 1 30); do curl -s --max-time 5 https://amazonlinux-2-repos-${AWS::Region}.s3.dualstack.${AWS::Region}.amazonaws.com && break || sleep 10; done
           yum install -y httpd
           systemctl start httpd
           systemctl enable httpd
@@ -473,7 +458,7 @@ Resources:
       UserData:
         Fn::Base64: !Sub |
           #!/bin/bash
-          for i in $(seq 1 30); do curl -s --max-time 5 https://amazonlinux-2-repos-us-east-1.s3.dualstack.us-east-1.amazonaws.com && break || sleep 10; done
+          for i in $(seq 1 30); do curl -s --max-time 5 https://amazonlinux-2-repos-${AWS::Region}.s3.dualstack.${AWS::Region}.amazonaws.com && break || sleep 10; done
           yum install -y httpd
           systemctl start httpd
           systemctl enable httpd
@@ -482,8 +467,8 @@ Resources:
         - Key: Name
           Value: !Sub "spoke-b-2-${AWS::StackName}"
 
-
-# Spoke NLB resources
+# Spoke NLB resources - Internal NLBs with static private IPs front EC2 workloads.
+# Static IPs allow the Edge NLB to register spoke NLB targets directly in CloudFormation.
   SpokeANLB:
     Type: AWS::ElasticLoadBalancingV2::LoadBalancer
     Properties:
@@ -491,7 +476,7 @@ Resources:
       Scheme: internal
       Type: network
       SubnetMappings:
-        - SubnetId: !Ref SubnetAWorkload
+        - SubnetId: !Ref SubnetAWorkload1
           PrivateIPv4Address: "10.1.1.10"
         - SubnetId: !Ref SubnetAWorkload2
           PrivateIPv4Address: "10.1.2.10"
@@ -508,7 +493,7 @@ Resources:
       TargetType: instance
       VpcId: !Ref SpokeVPCA
       Targets:
-        - Id: !Ref EC2SubnetA
+        - Id: !Ref EC2SubnetA1
         - Id: !Ref EC2SubnetA2
       Tags:
         - Key: Name
@@ -531,7 +516,7 @@ Resources:
       Scheme: internal
       Type: network
       SubnetMappings:
-        - SubnetId: !Ref SubnetBWorkload
+        - SubnetId: !Ref SubnetBWorkload1
           PrivateIPv4Address: "10.2.1.10"
         - SubnetId: !Ref SubnetBWorkload2
           PrivateIPv4Address: "10.2.2.10"
@@ -548,7 +533,7 @@ Resources:
       TargetType: instance
       VpcId: !Ref SpokeVPCB
       Targets:
-        - Id: !Ref EC2SubnetB
+        - Id: !Ref EC2SubnetB1
         - Id: !Ref EC2SubnetB2
       Tags:
         - Key: Name
@@ -564,8 +549,8 @@ Resources:
         - Type: forward
           TargetGroupArn: !Ref SpokeBNLBTargetGroupHTTP
 
-
-# Edge VPC
+# Edge VPC - Central VPC hosting IGW, Network Firewall, NLB, and NAT Gateways
+# All inbound internet traffic enters through this VPC and is inspected by the firewall before reaching spoke workloads
   EdgeVPC:
     Type: AWS::EC2::VPC
     Properties:
@@ -580,11 +565,9 @@ Resources:
   EdgeFirewallSubnet1:
     Type: AWS::EC2::Subnet
     Properties:
-      VpcId:
-        Ref: EdgeVPC
+      VpcId: !Ref EdgeVPC
       CidrBlock: "100.64.0.16/28"
-      AvailabilityZone:
-        Ref: AvailabilityZoneSelection1
+      AvailabilityZone: !Ref AvailabilityZoneSelection1
       MapPublicIpOnLaunch: false
       Tags:
         - Key: Name
@@ -593,11 +576,9 @@ Resources:
   EdgeFirewallSubnet2:
     Type: AWS::EC2::Subnet
     Properties:
-      VpcId:
-        Ref: EdgeVPC
+      VpcId: !Ref EdgeVPC
       CidrBlock: "100.64.0.32/28"
-      AvailabilityZone:
-        Ref: AvailabilityZoneSelection2
+      AvailabilityZone: !Ref AvailabilityZoneSelection2
       MapPublicIpOnLaunch: false
       Tags:
         - Key: Name
@@ -606,11 +587,9 @@ Resources:
   EdgePublicSubnet1:
     Type: AWS::EC2::Subnet
     Properties:
-      VpcId:
-        Ref: EdgeVPC
+      VpcId: !Ref EdgeVPC
       CidrBlock: "100.64.1.0/24"
-      AvailabilityZone:
-        Ref: AvailabilityZoneSelection1
+      AvailabilityZone: !Ref AvailabilityZoneSelection1
       MapPublicIpOnLaunch: true
       Tags:
         - Key: Name
@@ -619,11 +598,9 @@ Resources:
   EdgePublicSubnet2:
     Type: AWS::EC2::Subnet
     Properties:
-      VpcId:
-        Ref: EdgeVPC
+      VpcId: !Ref EdgeVPC
       CidrBlock: "100.64.2.0/24"
-      AvailabilityZone:
-        Ref: AvailabilityZoneSelection2
+      AvailabilityZone: !Ref AvailabilityZoneSelection2
       MapPublicIpOnLaunch: true
       Tags:
         - Key: Name
@@ -632,11 +609,9 @@ Resources:
   EdgeTGWSubnet1:
     Type: AWS::EC2::Subnet
     Properties:
-      VpcId:
-        Ref: EdgeVPC
+      VpcId: !Ref EdgeVPC
       CidrBlock: "100.64.0.0/28"
-      AvailabilityZone:
-        Ref: AvailabilityZoneSelection1
+      AvailabilityZone: !Ref AvailabilityZoneSelection1
       MapPublicIpOnLaunch: false
       Tags:
         - Key: Name
@@ -645,11 +620,9 @@ Resources:
   EdgeTGWSubnet2:
     Type: AWS::EC2::Subnet
     Properties:
-      VpcId:
-        Ref: EdgeVPC
+      VpcId: !Ref EdgeVPC
       CidrBlock: "100.64.0.48/28"
-      AvailabilityZone:
-        Ref: AvailabilityZoneSelection2
+      AvailabilityZone: !Ref AvailabilityZoneSelection2
       MapPublicIpOnLaunch: false
       Tags:
         - Key: Name
@@ -665,10 +638,8 @@ Resources:
   AttachEdgeGateway:
     Type: AWS::EC2::VPCGatewayAttachment
     Properties:
-      VpcId:
-        !Ref EdgeVPC
-      InternetGatewayId:
-        !Ref EdgeInternetGateway
+      VpcId: !Ref EdgeVPC
+      InternetGatewayId: !Ref EdgeInternetGateway
 
   EdgeNATEIP1:
     Type: "AWS::EC2::EIP"
@@ -683,12 +654,8 @@ Resources:
   EdgeNATGateway1:
     Type: "AWS::EC2::NatGateway"
     Properties:
-      AllocationId:
-        Fn::GetAtt:
-          - EdgeNATEIP1
-          - AllocationId
-      SubnetId:
-        Ref: EdgePublicSubnet1
+      AllocationId: !GetAtt EdgeNATEIP1.AllocationId
+      SubnetId: !Ref EdgePublicSubnet1
       Tags:
         - Key: Name
           Value: !Sub "edge-natgw-1-${AWS::StackName}"
@@ -696,23 +663,21 @@ Resources:
   EdgeNATGateway2:
     Type: "AWS::EC2::NatGateway"
     Properties:
-      AllocationId:
-        Fn::GetAtt:
-          - EdgeNATEIP2
-          - AllocationId
-      SubnetId:
-        Ref: EdgePublicSubnet2
+      AllocationId: !GetAtt EdgeNATEIP2.AllocationId
+      SubnetId: !Ref EdgePublicSubnet2
       Tags:
         - Key: Name
           Value: !Sub "edge-natgw-2-${AWS::StackName}"
 
-
-# Edge VPC ALB
-  EdgeALBSecurityGroup:
+# Edge VPC NLB - Internet-facing NLB receives inspected inbound traffic and forwards to spoke NLBs
+# Both 1-AZ and 2-AZ templates use NLB (not ALB) to maintain the same architecture pattern.
+# NLB operates at Layer 4, which aligns with the NFW ingress use case for non-web traffic.
+# Spoke NLBs use static private IPs (via SubnetMappings) so they can be registered as Edge NLB targets directly.
+  EdgeNLBSecurityGroup:
     Type: AWS::EC2::SecurityGroup
     Properties:
-      GroupDescription: "Allow HTTP and HTTPS inbound traffic to ALB"
-      GroupName: !Sub "edge-alb-sg-${AWS::StackName}"
+      GroupDescription: "Allow HTTP and TLS inbound traffic to Edge NLB"
+      GroupName: !Sub "edge-nlb-sg-${AWS::StackName}"
       VpcId: !Ref EdgeVPC
       SecurityGroupIngress:
         - IpProtocol: tcp
@@ -722,34 +687,35 @@ Resources:
           ToPort: 80
         - IpProtocol: tcp
           CidrIp: 0.0.0.0/0
-          Description: "Allow HTTPS from internet"
+          Description: "Allow TLS from internet"
           FromPort: 443
           ToPort: 443
 
-  EdgeALB:
+  EdgeNLB:
     Type: AWS::ElasticLoadBalancingV2::LoadBalancer
     DependsOn: AttachEdgeGateway
     Properties:
-      Name: !Sub "edge-alb-${AWS::StackName}"
+      Name: !Sub "edge-nlb-${AWS::StackName}"
       Scheme: internet-facing
-      Type: application
+      Type: network
       SecurityGroups:
-        - !Ref EdgeALBSecurityGroup
+        - !Ref EdgeNLBSecurityGroup
       Subnets:
         - !Ref EdgePublicSubnet1
         - !Ref EdgePublicSubnet2
       Tags:
         - Key: Name
-          Value: !Sub "edge-alb-${AWS::StackName}"
+          Value: !Sub "edge-nlb-${AWS::StackName}"
 
   # IP-type target group targeting all spoke NLB static IPs via TGW (port 80 only)
-  # TLS is terminated at the ALB; all downstream traffic is plaintext HTTP
-  EdgeALBTargetGroupHTTP:
+  # TLS is terminated at the Edge NLB; all downstream traffic is plaintext HTTP
+  # AvailabilityZone: "all" is required for cross-VPC IP targets routed via TGW
+  EdgeNLBTargetGroupHTTP:
     Type: AWS::ElasticLoadBalancingV2::TargetGroup
     Properties:
       Name: !Sub "e-http-${AWS::StackName}"
       Port: 80
-      Protocol: HTTP
+      Protocol: TCP
       TargetType: ip
       VpcId: !Ref EdgeVPC
       Targets:
@@ -765,33 +731,36 @@ Resources:
         - Key: Name
           Value: !Sub "e-tg-http-${AWS::StackName}"
 
-  EdgeALBListenerHTTP:
+  EdgeNLBListenerHTTP:
     Type: AWS::ElasticLoadBalancingV2::Listener
     Properties:
-      LoadBalancerArn: !Ref EdgeALB
+      LoadBalancerArn: !Ref EdgeNLB
       Port: 80
-      Protocol: HTTP
+      Protocol: TCP
       DefaultActions:
         - Type: forward
-          TargetGroupArn: !Ref EdgeALBTargetGroupHTTP
+          TargetGroupArn: !Ref EdgeNLBTargetGroupHTTP
 
-  # HTTPS listener terminates TLS using ACM certificate and forwards to port 80 HTTP target group
-  EdgeALBListenerHTTPS:
+  # TLS listener terminates TLS using ACM certificate and forwards to port 80 TCP target group
+  EdgeNLBListenerTLS:
     Type: AWS::ElasticLoadBalancingV2::Listener
-    Condition: HasALBCertificate
+    Condition: HasNLBCertificate
     Properties:
-      LoadBalancerArn: !Ref EdgeALB
+      LoadBalancerArn: !Ref EdgeNLB
       Port: 443
-      Protocol: HTTPS
+      Protocol: TLS
       Certificates:
-        - CertificateArn: !Ref ALBCertificateArn
+        - CertificateArn: !Ref NLBCertificateArn
       SslPolicy: ELBSecurityPolicy-TLS13-1-2-2021-06
       DefaultActions:
         - Type: forward
-          TargetGroupArn: !Ref EdgeALBTargetGroupHTTP
+          TargetGroupArn: !Ref EdgeNLBTargetGroupHTTP
 
+# Network Firewall - Inspects all inbound internet traffic before it reaches the NLB and spoke workloads
+# The firewall is deployed in Firewall Subnets of the Edge VPC across both AZs
+# NOTE: EndpointIds are returned in the order of SubnetMappings. The routes below assume
+# index 0 = AZ1 (EdgeFirewallSubnet1) and index 1 = AZ2 (EdgeFirewallSubnet2).
 
-# Network Firewall
   IngressAllowListRuleGroup:
     Type: 'AWS::NetworkFirewall::RuleGroup'
     Properties:
@@ -802,11 +771,9 @@ Resources:
           RulesString: |
             # Strict rule ordering ingress security template
             # This rule group is defined but NOT referenced in the firewall policy by default.
-            # Enable it by adding a StatefulRuleGroupReference to the IngressFirewallPolicy when
-            # you are ready to move beyond log-only mode.
             # Visit https://aws.github.io/aws-security-services-best-practices/guides/network-firewall/ for best practices
 
-            # Allow inbound HTTP to HOME_NET (for ALB health checks and web traffic)
+            # Allow inbound HTTP to HOME_NET
             pass tcp any any -> $HOME_NET 80 (flow:to_server; msg:"Allow inbound HTTP"; sid:300001;)
 
             # Allow inbound HTTPS to HOME_NET
@@ -838,22 +805,12 @@ Resources:
         RulesSource:
           RulesString: |
             # Ingress inspection log-only rules - Strict rule ordering
-            # This rule group alerts on inbound traffic patterns without blocking.
             # Visit https://aws.github.io/aws-security-services-best-practices/guides/network-firewall/ for best practices
 
-            # Alert on inbound HTTP traffic
             alert http any any -> $HOME_NET any (msg:"Inbound HTTP traffic"; flow:to_server; sid:200001;)
-
-            # Alert on inbound HTTPS/TLS traffic
             alert tls any any -> $HOME_NET any (msg:"Inbound TLS traffic"; flow:to_server; sid:200002;)
-
-            # Alert on inbound SSH
             alert ssh any any -> $HOME_NET any (msg:"Inbound SSH traffic"; flow:to_server; sid:200003;)
-
-            # Alert on inbound ICMP
             alert icmp any any -> $HOME_NET any (msg:"Inbound ICMP traffic"; sid:200004;)
-
-            # Alert on any other inbound traffic
             alert ip any any -> $HOME_NET any (msg:"Inbound IP traffic"; flow:to_server; sid:200005;)
         StatefulRuleOptions:
           RuleOrder: STRICT_ORDER
@@ -937,13 +894,12 @@ Resources:
             LogDestination:
               logGroup: !Sub "/${AWS::StackName}/ingress-fw/alert"
 
-
 # Transit Gateway - Connects Edge VPC to Spoke VPCs
   CentralTransitGateway:
     Type: "AWS::EC2::TransitGateway"
     Properties:
       AmazonSideAsn: 65000
-      Description: "TGW Centralized Ingress Inspection"
+      Description: "TGW Centralized Ingress Inspection - Two AZ"
       AutoAcceptSharedAttachments: "disable"
       DefaultRouteTableAssociation: "disable"
       DefaultRouteTablePropagation: "disable"
@@ -953,7 +909,6 @@ Resources:
         - Key: Name
           Value: !Sub "tgw-${AWS::StackName}"
 
-  # Edge VPC attachment with ApplianceModeSupport to ensure symmetric routing through the firewall
   AttachEdgeVPC:
     Type: "AWS::EC2::TransitGatewayAttachment"
     Properties:
@@ -972,7 +927,7 @@ Resources:
     Type: "AWS::EC2::TransitGatewayAttachment"
     Properties:
       SubnetIds:
-        - !Ref SubnetATGW
+        - !Ref SubnetATGW1
         - !Ref SubnetATGW2
       Tags:
         - Key: Name
@@ -984,7 +939,7 @@ Resources:
     Type: "AWS::EC2::TransitGatewayAttachment"
     Properties:
       SubnetIds:
-        - !Ref SubnetBTGW
+        - !Ref SubnetBTGW1
         - !Ref SubnetBTGW2
       Tags:
         - Key: Name
@@ -992,7 +947,6 @@ Resources:
       TransitGatewayId: !Ref CentralTransitGateway
       VpcId: !Ref SpokeVPCB
 
-  # Transit Gateway Route Tables
   SpokeRouteTable:
     Type: "AWS::EC2::TransitGatewayRouteTable"
     Properties:
@@ -1009,7 +963,6 @@ Resources:
           Value: !Sub "inspection-route-table-${AWS::StackName}"
       TransitGatewayId: !Ref CentralTransitGateway
 
-  # Associate both spoke attachments with the Spoke TGW route table
   AssociateVPCARouteTable:
     Type: AWS::EC2::TransitGatewayRouteTableAssociation
     Properties:
@@ -1022,14 +975,12 @@ Resources:
       TransitGatewayAttachmentId: !Ref AttachSpokeVPCB
       TransitGatewayRouteTableId: !Ref SpokeRouteTable
 
-  # Associate Edge VPC attachment with the Inspection TGW route table
   AssociateEdgeVPCRouteTable:
     Type: AWS::EC2::TransitGatewayRouteTableAssociation
     Properties:
       TransitGatewayAttachmentId: !Ref AttachEdgeVPC
       TransitGatewayRouteTableId: !Ref InspectionRouteTable
 
-  # Propagate spoke routes to inspection route table for return traffic
   PropagateVPCARoute:
     Type: AWS::EC2::TransitGatewayRouteTablePropagation
     Properties:
@@ -1042,7 +993,6 @@ Resources:
       TransitGatewayAttachmentId: !Ref AttachSpokeVPCB
       TransitGatewayRouteTableId: !Ref InspectionRouteTable
 
-  # Route all spoke traffic to Edge VPC for inspection
   SpokeDefaultRoute:
     Type: AWS::EC2::TransitGatewayRoute
     Properties:
@@ -1050,9 +1000,11 @@ Resources:
       TransitGatewayAttachmentId: !Ref AttachEdgeVPC
       TransitGatewayRouteTableId: !Ref SpokeRouteTable
 
+# Edge VPC Route Tables - Per-AZ routing for symmetric firewall inspection
+# NOTE on firewall endpoint ordering: EndpointIds index 0 corresponds to EdgeFirewallSubnet1 (AZ1)
+# and index 1 corresponds to EdgeFirewallSubnet2 (AZ2), matching the SubnetMappings order above.
 
-# Edge VPC Route Tables
-  # IGW Ingress Route Table
+  # IGW Ingress Route Table - steers inbound traffic through firewall before reaching NLB
   EdgeIGWIngressRouteTable:
     Type: AWS::EC2::RouteTable
     Properties:
@@ -1067,7 +1019,7 @@ Resources:
       RouteTableId: !Ref EdgeIGWIngressRouteTable
       GatewayId: !Ref EdgeInternetGateway
 
-  # Route traffic destined for Public Subnet AZ1 CIDR through the AZ1 firewall endpoint
+  # Route Public Subnet AZ1 CIDR through AZ1 firewall endpoint
   EdgeIGWIngressPublicSubnet1Route:
     Type: AWS::EC2::Route
     DependsOn: IngressFirewall
@@ -1076,7 +1028,7 @@ Resources:
       VpcEndpointId: !Select [1, !Split [":", !Select [0, !GetAtt IngressFirewall.EndpointIds]]]
       RouteTableId: !Ref EdgeIGWIngressRouteTable
 
-  # Route traffic destined for Public Subnet AZ2 CIDR through the AZ2 firewall endpoint
+  # Route Public Subnet AZ2 CIDR through AZ2 firewall endpoint
   EdgeIGWIngressPublicSubnet2Route:
     Type: AWS::EC2::Route
     DependsOn: IngressFirewall
@@ -1096,7 +1048,6 @@ Resources:
 
   EdgeFirewallRouteTable1Association:
     Type: AWS::EC2::SubnetRouteTableAssociation
-    DependsOn: EdgeFirewallSubnet1
     Properties:
       RouteTableId: !Ref EdgeFirewallRouteTable1
       SubnetId: !Ref EdgeFirewallSubnet1
@@ -1128,7 +1079,6 @@ Resources:
 
   EdgeFirewallRouteTable2Association:
     Type: AWS::EC2::SubnetRouteTableAssociation
-    DependsOn: EdgeFirewallSubnet2
     Properties:
       RouteTableId: !Ref EdgeFirewallRouteTable2
       SubnetId: !Ref EdgeFirewallSubnet2
@@ -1149,7 +1099,7 @@ Resources:
       TransitGatewayId: !Ref CentralTransitGateway
       RouteTableId: !Ref EdgeFirewallRouteTable2
 
-  # Public Subnet AZ1 Route Table: 0.0.0.0/0 → FW Endpoint (symmetric inspection)
+  # Public Subnet AZ1 Route Table: 0.0.0.0/0 → FW Endpoint (symmetric inspection), 10.0.0.0/8 → TGW
   EdgePublicRouteTable1:
     Type: AWS::EC2::RouteTable
     Properties:
@@ -1160,7 +1110,6 @@ Resources:
 
   EdgePublicRouteTable1Association:
     Type: AWS::EC2::SubnetRouteTableAssociation
-    DependsOn: EdgePublicSubnet1
     Properties:
       RouteTableId: !Ref EdgePublicRouteTable1
       SubnetId: !Ref EdgePublicSubnet1
@@ -1192,7 +1141,6 @@ Resources:
 
   EdgePublicRouteTable2Association:
     Type: AWS::EC2::SubnetRouteTableAssociation
-    DependsOn: EdgePublicSubnet2
     Properties:
       RouteTableId: !Ref EdgePublicRouteTable2
       SubnetId: !Ref EdgePublicSubnet2
@@ -1224,7 +1172,6 @@ Resources:
 
   EdgeTGWRouteTable1Association:
     Type: AWS::EC2::SubnetRouteTableAssociation
-    DependsOn: EdgeTGWSubnet1
     Properties:
       RouteTableId: !Ref EdgeTGWRouteTable1
       SubnetId: !Ref EdgeTGWSubnet1
@@ -1248,7 +1195,6 @@ Resources:
 
   EdgeTGWRouteTable2Association:
     Type: AWS::EC2::SubnetRouteTableAssociation
-    DependsOn: EdgeTGWSubnet2
     Properties:
       RouteTableId: !Ref EdgeTGWRouteTable2
       SubnetId: !Ref EdgeTGWSubnet2
@@ -1261,10 +1207,9 @@ Resources:
       NatGatewayId: !Ref EdgeNATGateway2
       RouteTableId: !Ref EdgeTGWRouteTable2
 
+# Spoke VPC Route Tables - per-AZ workload and TGW subnets
 
-# Spoke VPC Route Tables
-  # Spoke A workload subnet AZ1 route table
-  SubnetAWorkloadRouteTable:
+  SubnetAWorkload1RouteTable:
     Type: AWS::EC2::RouteTable
     Properties:
       VpcId: !Ref SpokeVPCA
@@ -1272,22 +1217,20 @@ Resources:
         - Key: Name
           Value: !Sub "spoke-a-workload-route-table-1-${AWS::StackName}"
 
-  SubnetAWorkloadRouteTableAssociation:
+  SubnetAWorkload1RouteTableAssociation:
     Type: AWS::EC2::SubnetRouteTableAssociation
-    DependsOn: SubnetAWorkload
     Properties:
-      RouteTableId: !Ref SubnetAWorkloadRouteTable
-      SubnetId: !Ref SubnetAWorkload
+      RouteTableId: !Ref SubnetAWorkload1RouteTable
+      SubnetId: !Ref SubnetAWorkload1
 
-  SubnetAWorkloadDefaultRoute:
+  SubnetAWorkload1DefaultRoute:
     Type: AWS::EC2::Route
     DependsOn: AttachSpokeVPCA
     Properties:
       DestinationCidrBlock: "0.0.0.0/0"
       TransitGatewayId: !Ref CentralTransitGateway
-      RouteTableId: !Ref SubnetAWorkloadRouteTable
+      RouteTableId: !Ref SubnetAWorkload1RouteTable
 
-  # Spoke A workload subnet AZ2 route table
   SubnetAWorkload2RouteTable:
     Type: AWS::EC2::RouteTable
     Properties:
@@ -1298,7 +1241,6 @@ Resources:
 
   SubnetAWorkload2RouteTableAssociation:
     Type: AWS::EC2::SubnetRouteTableAssociation
-    DependsOn: SubnetAWorkload2
     Properties:
       RouteTableId: !Ref SubnetAWorkload2RouteTable
       SubnetId: !Ref SubnetAWorkload2
@@ -1311,8 +1253,7 @@ Resources:
       TransitGatewayId: !Ref CentralTransitGateway
       RouteTableId: !Ref SubnetAWorkload2RouteTable
 
-  # Spoke B workload subnet AZ1 route table
-  SubnetBWorkloadRouteTable:
+  SubnetBWorkload1RouteTable:
     Type: AWS::EC2::RouteTable
     Properties:
       VpcId: !Ref SpokeVPCB
@@ -1320,22 +1261,20 @@ Resources:
         - Key: Name
           Value: !Sub "spoke-b-workload-route-table-1-${AWS::StackName}"
 
-  SubnetBWorkloadRouteTableAssociation:
+  SubnetBWorkload1RouteTableAssociation:
     Type: AWS::EC2::SubnetRouteTableAssociation
-    DependsOn: SubnetBWorkload
     Properties:
-      RouteTableId: !Ref SubnetBWorkloadRouteTable
-      SubnetId: !Ref SubnetBWorkload
+      RouteTableId: !Ref SubnetBWorkload1RouteTable
+      SubnetId: !Ref SubnetBWorkload1
 
-  SubnetBWorkloadDefaultRoute:
+  SubnetBWorkload1DefaultRoute:
     Type: AWS::EC2::Route
     DependsOn: AttachSpokeVPCB
     Properties:
       DestinationCidrBlock: "0.0.0.0/0"
       TransitGatewayId: !Ref CentralTransitGateway
-      RouteTableId: !Ref SubnetBWorkloadRouteTable
+      RouteTableId: !Ref SubnetBWorkload1RouteTable
 
-  # Spoke B workload subnet AZ2 route table
   SubnetBWorkload2RouteTable:
     Type: AWS::EC2::RouteTable
     Properties:
@@ -1346,7 +1285,6 @@ Resources:
 
   SubnetBWorkload2RouteTableAssociation:
     Type: AWS::EC2::SubnetRouteTableAssociation
-    DependsOn: SubnetBWorkload2
     Properties:
       RouteTableId: !Ref SubnetBWorkload2RouteTable
       SubnetId: !Ref SubnetBWorkload2
@@ -1359,8 +1297,8 @@ Resources:
       TransitGatewayId: !Ref CentralTransitGateway
       RouteTableId: !Ref SubnetBWorkload2RouteTable
 
-  # Dedicated route tables for TGW subnets (default local routes only)
-  SubnetATGWRouteTable:
+  # TGW subnets (default local routes only)
+  SubnetATGW1RouteTable:
     Type: AWS::EC2::RouteTable
     Properties:
       VpcId: !Ref SpokeVPCA
@@ -1368,12 +1306,11 @@ Resources:
         - Key: Name
           Value: !Sub "spoke-a-tgw-route-table-1-${AWS::StackName}"
 
-  SubnetATGWRouteTableAssociation:
+  SubnetATGW1RouteTableAssociation:
     Type: AWS::EC2::SubnetRouteTableAssociation
-    DependsOn: SubnetATGW
     Properties:
-      RouteTableId: !Ref SubnetATGWRouteTable
-      SubnetId: !Ref SubnetATGW
+      RouteTableId: !Ref SubnetATGW1RouteTable
+      SubnetId: !Ref SubnetATGW1
 
   SubnetATGW2RouteTable:
     Type: AWS::EC2::RouteTable
@@ -1385,12 +1322,11 @@ Resources:
 
   SubnetATGW2RouteTableAssociation:
     Type: AWS::EC2::SubnetRouteTableAssociation
-    DependsOn: SubnetATGW2
     Properties:
       RouteTableId: !Ref SubnetATGW2RouteTable
       SubnetId: !Ref SubnetATGW2
 
-  SubnetBTGWRouteTable:
+  SubnetBTGW1RouteTable:
     Type: AWS::EC2::RouteTable
     Properties:
       VpcId: !Ref SpokeVPCB
@@ -1398,12 +1334,11 @@ Resources:
         - Key: Name
           Value: !Sub "spoke-b-tgw-route-table-1-${AWS::StackName}"
 
-  SubnetBTGWRouteTableAssociation:
+  SubnetBTGW1RouteTableAssociation:
     Type: AWS::EC2::SubnetRouteTableAssociation
-    DependsOn: SubnetBTGW
     Properties:
-      RouteTableId: !Ref SubnetBTGWRouteTable
-      SubnetId: !Ref SubnetBTGW
+      RouteTableId: !Ref SubnetBTGW1RouteTable
+      SubnetId: !Ref SubnetBTGW1
 
   SubnetBTGW2RouteTable:
     Type: AWS::EC2::RouteTable
@@ -1415,17 +1350,34 @@ Resources:
 
   SubnetBTGW2RouteTableAssociation:
     Type: AWS::EC2::SubnetRouteTableAssociation
-    DependsOn: SubnetBTGW2
     Properties:
       RouteTableId: !Ref SubnetBTGW2RouteTable
       SubnetId: !Ref SubnetBTGW2
 
+# ============================================================================
+# Traffic Flow Summary (same pattern as 1-AZ, per-AZ routing for HA):
+#
+# INGRESS PATH:
+#   Internet → IGW → (IGW Ingress RT: Public CIDR → same-AZ FW Endpoint) → Firewall
+#   → (local route) → NLB in Public Subnet → (Public RT: 10.0.0.0/8 → TGW)
+#   → TGW → Spoke NLB → EC2 httpd
+#
+# INGRESS RETURN (symmetric through firewall):
+#   EC2 → Spoke NLB → TGW → Edge NLB → (Public RT: 0.0.0.0/0 → same-AZ FW Endpoint)
+#   → Firewall → (Firewall RT: 0.0.0.0/0 → IGW) → Internet
+#
+# SPOKE EGRESS (e.g., yum install, SSM):
+#   Spoke EC2 → TGW → (TGW Subnet RT: 0.0.0.0/0 → same-AZ NAT GW) → NAT Gateway
+#   → (Public RT: 0.0.0.0/0 → same-AZ FW Endpoint) → Firewall
+#   → (Firewall RT: 0.0.0.0/0 → IGW) → Internet
+# ============================================================================
+
 Outputs:
-  EdgeALBDNSName:
-    Description: Edge ALB DNS Name
-    Value: !GetAtt EdgeALB.DNSName
+  EdgeNLBDNSName:
+    Description: Edge NLB DNS Name
+    Value: !GetAtt EdgeNLB.DNSName
     Export:
-      Name: !Sub "${AWS::StackName}-EdgeALBDNSName"
+      Name: !Sub "${AWS::StackName}-EdgeNLBDNSName"
 
   IngressFirewallEndpointAZ1:
     Description: Ingress Network Firewall Endpoint ID (AZ1)
@@ -1444,36 +1396,6 @@ Outputs:
     Value: !Ref CentralTransitGateway
     Export:
       Name: !Sub "${AWS::StackName}-TransitGatewayId"
-
-  EdgeALBSecurityGroupId:
-    Description: Edge ALB Security Group ID
-    Value: !Ref EdgeALBSecurityGroup
-    Export:
-      Name: !Sub "${AWS::StackName}-EdgeALBSecGroup"
-
-  EdgeNATGateway1Id:
-    Description: Edge NAT Gateway ID (AZ1)
-    Value: !Ref EdgeNATGateway1
-    Export:
-      Name: !Sub "${AWS::StackName}-EdgeNATGateway1"
-
-  EdgeNATGateway2Id:
-    Description: Edge NAT Gateway ID (AZ2)
-    Value: !Ref EdgeNATGateway2
-    Export:
-      Name: !Sub "${AWS::StackName}-EdgeNATGateway2"
-
-  EdgeNATEIP1AllocationId:
-    Description: Edge NAT Gateway Elastic IP (AZ1)
-    Value: !Ref EdgeNATEIP1
-    Export:
-      Name: !Sub "${AWS::StackName}-EdgeNATEIP1"
-
-  EdgeNATEIP2AllocationId:
-    Description: Edge NAT Gateway Elastic IP (AZ2)
-    Value: !Ref EdgeNATEIP2
-    Export:
-      Name: !Sub "${AWS::StackName}-EdgeNATEIP2"
 
   SpokeASecurityGroupId:
     Description: Spoke A Security Group ID
@@ -1516,3 +1438,11 @@ Outputs:
     Value: !Ref AttachEdgeVPC
     Export:
       Name: !Sub "${AWS::StackName}-EdgeVPCAttachment"
+
+  AvailabilityZone1:
+    Description: First Availability Zone used
+    Value: !Ref AvailabilityZoneSelection1
+
+  AvailabilityZone2:
+    Description: Second Availability Zone used
+    Value: !Ref AvailabilityZoneSelection2

--- a/centralized_architecture/centralized_ingress_two_az/anfw-centralized-ingress-2az-template.yaml
+++ b/centralized_architecture/centralized_ingress_two_az/anfw-centralized-ingress-2az-template.yaml
@@ -8,7 +8,7 @@
 #CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 AWSTemplateFormatVersion: "2010-09-09"
-Description: "AWS Network Firewall Demo - Centralized ingress inspection with Edge VPC, Network Firewall, NLB, Transit Gateway, and spoke VPCs with NLBs (single AZ deployment)"
+Description: "AWS Network Firewall Demo - Centralized ingress inspection with Edge VPC, Network Firewall, ALB, Transit Gateway, and spoke VPCs with NLBs (two AZ deployment)"
 
 Metadata:
   "AWS::CloudFormation::Interface":
@@ -16,21 +16,36 @@ Metadata:
       - Label:
           default: "VPC Parameters"
         Parameters:
-          - AvailabilityZoneSelection
+          - AvailabilityZoneSelection1
+          - AvailabilityZoneSelection2
+          - ALBCertificateArn
       - Label:
           default: "EC2 Parameters"
         Parameters:
           - LatestAmiId
 Parameters:
-  AvailabilityZoneSelection:
-    Description: Availability Zone
+  AvailabilityZoneSelection1:
+    Description: First Availability Zone
     Type: AWS::EC2::AvailabilityZone::Name
     Default: us-east-1a
+
+  AvailabilityZoneSelection2:
+    Description: Second Availability Zone
+    Type: AWS::EC2::AvailabilityZone::Name
+    Default: us-east-1b
+
+  ALBCertificateArn:
+    Description: ACM Certificate ARN for the ALB HTTPS listener (leave empty to skip HTTPS listener)
+    Type: String
+    Default: ""
 
   LatestAmiId:
     Description: Latest EC2 AMI from Systems Manager Parameter Store
     Type: 'AWS::SSM::Parameter::Value<AWS::EC2::Image::Id>'
     Default: '/aws/service/ami-amazon-linux-latest/amzn2-ami-hvm-x86_64-gp2'
+
+Conditions:
+  HasALBCertificate: !Not [!Equals [!Ref ALBCertificateArn, ""]]
 
 Resources:
 # Spoke VPC A
@@ -52,11 +67,24 @@ Resources:
         Ref: SpokeVPCA
       CidrBlock: "10.1.1.0/24"
       AvailabilityZone: 
-        Ref: AvailabilityZoneSelection
+        Ref: AvailabilityZoneSelection1
       MapPublicIpOnLaunch: false
       Tags:
         - Key: Name
-          Value: !Sub "spoke-a-workload-${AWS::StackName}"
+          Value: !Sub "spoke-a-workload-1-${AWS::StackName}"
+
+  SubnetAWorkload2:
+    Type: AWS::EC2::Subnet
+    Properties:
+      VpcId:
+        Ref: SpokeVPCA
+      CidrBlock: "10.1.2.0/24"
+      AvailabilityZone: 
+        Ref: AvailabilityZoneSelection2
+      MapPublicIpOnLaunch: false
+      Tags:
+        - Key: Name
+          Value: !Sub "spoke-a-workload-2-${AWS::StackName}"
 
   SubnetATGW:
     Type: AWS::EC2::Subnet
@@ -65,11 +93,24 @@ Resources:
         Ref: SpokeVPCA
       CidrBlock: "10.1.0.0/28"
       AvailabilityZone:
-        Ref: AvailabilityZoneSelection
+        Ref: AvailabilityZoneSelection1
       MapPublicIpOnLaunch: false
       Tags:
         - Key: Name
-          Value: !Sub "spoke-a-tgw-${AWS::StackName}"
+          Value: !Sub "spoke-a-tgw-1-${AWS::StackName}"
+
+  SubnetATGW2:
+    Type: AWS::EC2::Subnet
+    Properties:
+      VpcId:
+        Ref: SpokeVPCA
+      CidrBlock: "10.1.0.16/28"
+      AvailabilityZone:
+        Ref: AvailabilityZoneSelection2
+      MapPublicIpOnLaunch: false
+      Tags:
+        - Key: Name
+          Value: !Sub "spoke-a-tgw-2-${AWS::StackName}"
 
   SpokeAEndpointSecurityGroup:
     Type: AWS::EC2::SecurityGroup
@@ -91,6 +132,7 @@ Resources:
         ServiceName: !Sub "com.amazonaws.${AWS::Region}.ssm"
         SubnetIds: 
           - !Ref SubnetAWorkload
+          - !Ref SubnetAWorkload2
         VpcEndpointType: Interface
         VpcId: !Ref SpokeVPCA
 
@@ -103,6 +145,7 @@ Resources:
         ServiceName: !Sub "com.amazonaws.${AWS::Region}.ec2messages"
         SubnetIds: 
           - !Ref SubnetAWorkload
+          - !Ref SubnetAWorkload2
         VpcEndpointType: Interface
         VpcId: !Ref SpokeVPCA
 
@@ -115,6 +158,7 @@ Resources:
         ServiceName: !Sub "com.amazonaws.${AWS::Region}.ssmmessages"
         SubnetIds: 
           - !Ref SubnetAWorkload
+          - !Ref SubnetAWorkload2
         VpcEndpointType: Interface
         VpcId: !Ref SpokeVPCA
  
@@ -183,7 +227,7 @@ Resources:
   EC2SubnetA:
     Type: 'AWS::EC2::Instance'
     DependsOn:
-      - EdgeFirewallDefaultRoute
+      - EdgeFirewallDefaultRoute1
       - SubnetAWorkloadDefaultRoute
       - SpokeDefaultRoute
     Properties:
@@ -207,10 +251,41 @@ Resources:
           printf '%s\n' 'SSLProtocol -all +TLSv1.2' 'SSLCipherSuite ECDHE-ECDSA-AES128-GCM-SHA256:ECDHE-RSA-AES128-GCM-SHA256:ECDHE-ECDSA-AES256-GCM-SHA384:ECDHE-RSA-AES256-GCM-SHA384' 'SSLHonorCipherOrder on' > /etc/httpd/conf.d/ssl-hardening.conf
           systemctl start httpd
           systemctl enable httpd
-          echo "<html><body><h1>Spoke A - ${AvailabilityZoneSelection}</h1></body></html>" > /var/www/html/index.html
+          echo "<html><body><h1>Spoke A - ${AvailabilityZoneSelection1}</h1></body></html>" > /var/www/html/index.html
       Tags:
         - Key: Name
-          Value: !Sub "spoke-a-${AWS::StackName}"
+          Value: !Sub "spoke-a-1-${AWS::StackName}"
+
+  EC2SubnetA2:
+    Type: 'AWS::EC2::Instance'
+    DependsOn:
+      - EdgeFirewallDefaultRoute1
+      - SubnetAWorkload2DefaultRoute
+      - SpokeDefaultRoute
+    Properties:
+      ImageId: !Ref LatestAmiId
+      SubnetId: !Ref SubnetAWorkload2
+      InstanceType: t2.micro
+      SecurityGroupIds:
+        - !Ref SubnetASecGroup
+      IamInstanceProfile: !Ref SubnetAInstanceProfile
+      UserData:
+        Fn::Base64: !Sub |
+          #!/bin/bash
+          for i in $(seq 1 30); do curl -s --max-time 5 https://amazonlinux-2-repos-us-east-1.s3.dualstack.us-east-1.amazonaws.com && break || sleep 10; done
+          yum install -y httpd mod_ssl
+          openssl req -x509 -nodes -days 365 -newkey rsa:2048 \
+            -keyout /etc/pki/tls/private/localhost.key \
+            -out /etc/pki/tls/certs/localhost.crt \
+            -subj "/CN=localhost"
+          printf '%s\n' 'SSLProtocol -all +TLSv1.2' 'SSLCipherSuite ECDHE-ECDSA-AES128-GCM-SHA256:ECDHE-RSA-AES128-GCM-SHA256:ECDHE-ECDSA-AES256-GCM-SHA384:ECDHE-RSA-AES256-GCM-SHA384' 'SSLHonorCipherOrder on' > /etc/httpd/conf.d/ssl-hardening.conf
+          systemctl start httpd
+          systemctl enable httpd
+          echo "<html><body><h1>Spoke A - ${AvailabilityZoneSelection2}</h1></body></html>" > /var/www/html/index.html
+      Tags:
+        - Key: Name
+          Value: !Sub "spoke-a-2-${AWS::StackName}"
+
       
 # Spoke VPC B
   SpokeVPCB:
@@ -231,11 +306,24 @@ Resources:
         Ref: SpokeVPCB
       CidrBlock: "10.2.1.0/24"
       AvailabilityZone:
-        Ref: AvailabilityZoneSelection
+        Ref: AvailabilityZoneSelection1
       MapPublicIpOnLaunch: false
       Tags:
         - Key: Name
-          Value: !Sub "spoke-b-workload-${AWS::StackName}"
+          Value: !Sub "spoke-b-workload-1-${AWS::StackName}"
+
+  SubnetBWorkload2:
+    Type: AWS::EC2::Subnet
+    Properties:
+      VpcId:
+        Ref: SpokeVPCB
+      CidrBlock: "10.2.2.0/24"
+      AvailabilityZone:
+        Ref: AvailabilityZoneSelection2
+      MapPublicIpOnLaunch: false
+      Tags:
+        - Key: Name
+          Value: !Sub "spoke-b-workload-2-${AWS::StackName}"
 
   SubnetBTGW:
     Type: AWS::EC2::Subnet
@@ -244,11 +332,24 @@ Resources:
         Ref: SpokeVPCB
       CidrBlock: "10.2.0.0/28"
       AvailabilityZone:
-        Ref: AvailabilityZoneSelection
+        Ref: AvailabilityZoneSelection1
       MapPublicIpOnLaunch: false
       Tags:
         - Key: Name
-          Value: !Sub "spoke-b-tgw-${AWS::StackName}"
+          Value: !Sub "spoke-b-tgw-1-${AWS::StackName}"
+
+  SubnetBTGW2:
+    Type: AWS::EC2::Subnet
+    Properties:
+      VpcId:
+        Ref: SpokeVPCB
+      CidrBlock: "10.2.0.16/28"
+      AvailabilityZone:
+        Ref: AvailabilityZoneSelection2
+      MapPublicIpOnLaunch: false
+      Tags:
+        - Key: Name
+          Value: !Sub "spoke-b-tgw-2-${AWS::StackName}"
 
   SpokeBEndpointSecurityGroup:
     Type: AWS::EC2::SecurityGroup
@@ -270,6 +371,7 @@ Resources:
         ServiceName: !Sub "com.amazonaws.${AWS::Region}.ssm"
         SubnetIds: 
           - !Ref SubnetBWorkload
+          - !Ref SubnetBWorkload2
         VpcEndpointType: Interface
         VpcId: !Ref SpokeVPCB
 
@@ -282,6 +384,7 @@ Resources:
         ServiceName: !Sub "com.amazonaws.${AWS::Region}.ec2messages"
         SubnetIds: 
           - !Ref SubnetBWorkload
+          - !Ref SubnetBWorkload2
         VpcEndpointType: Interface
         VpcId: !Ref SpokeVPCB
 
@@ -294,6 +397,7 @@ Resources:
         ServiceName: !Sub "com.amazonaws.${AWS::Region}.ssmmessages"
         SubnetIds: 
           - !Ref SubnetBWorkload
+          - !Ref SubnetBWorkload2
         VpcEndpointType: Interface
         VpcId: !Ref SpokeVPCB
 
@@ -362,7 +466,7 @@ Resources:
   EC2SubnetB:
     Type: 'AWS::EC2::Instance'
     DependsOn:
-      - EdgeFirewallDefaultRoute
+      - EdgeFirewallDefaultRoute1
       - SubnetBWorkloadDefaultRoute
       - SpokeDefaultRoute
     Properties:
@@ -384,13 +488,43 @@ Resources:
           printf '%s\n' 'SSLProtocol -all +TLSv1.2' 'SSLCipherSuite ECDHE-ECDSA-AES128-GCM-SHA256:ECDHE-RSA-AES128-GCM-SHA256:ECDHE-ECDSA-AES256-GCM-SHA384:ECDHE-RSA-AES256-GCM-SHA384' 'SSLHonorCipherOrder on' > /etc/httpd/conf.d/ssl-hardening.conf
           systemctl start httpd
           systemctl enable httpd
-          echo "<html><body><h1>Spoke B - ${AvailabilityZoneSelection}</h1></body></html>" > /var/www/html/index.html
+          echo "<html><body><h1>Spoke B - ${AvailabilityZoneSelection1}</h1></body></html>" > /var/www/html/index.html
       Tags:
         - Key: Name
-          Value: !Sub "spoke-b-${AWS::StackName}"
+          Value: !Sub "spoke-b-1-${AWS::StackName}"
 
-# Spoke NLB resources - Internal NLBs with static private IPs front EC2 workloads.
-# Static IPs allow the Edge VPC ALB to register spoke NLB targets directly in CloudFormation.
+  EC2SubnetB2:
+    Type: 'AWS::EC2::Instance'
+    DependsOn:
+      - EdgeFirewallDefaultRoute1
+      - SubnetBWorkload2DefaultRoute
+      - SpokeDefaultRoute
+    Properties:
+      ImageId: !Ref LatestAmiId
+      SubnetId: !Ref SubnetBWorkload2
+      InstanceType: t2.micro
+      SecurityGroupIds:
+        - !Ref SubnetBSecGroup
+      IamInstanceProfile: !Ref SubnetBInstanceProfile
+      UserData:
+        Fn::Base64: !Sub |
+          #!/bin/bash
+          for i in $(seq 1 30); do curl -s --max-time 5 https://amazonlinux-2-repos-us-east-1.s3.dualstack.us-east-1.amazonaws.com && break || sleep 10; done
+          yum install -y httpd mod_ssl
+          openssl req -x509 -nodes -days 365 -newkey rsa:2048 \
+            -keyout /etc/pki/tls/private/localhost.key \
+            -out /etc/pki/tls/certs/localhost.crt \
+            -subj "/CN=localhost"
+          printf '%s\n' 'SSLProtocol -all +TLSv1.2' 'SSLCipherSuite ECDHE-ECDSA-AES128-GCM-SHA256:ECDHE-RSA-AES128-GCM-SHA256:ECDHE-ECDSA-AES256-GCM-SHA384:ECDHE-RSA-AES256-GCM-SHA384' 'SSLHonorCipherOrder on' > /etc/httpd/conf.d/ssl-hardening.conf
+          systemctl start httpd
+          systemctl enable httpd
+          echo "<html><body><h1>Spoke B - ${AvailabilityZoneSelection2}</h1></body></html>" > /var/www/html/index.html
+      Tags:
+        - Key: Name
+          Value: !Sub "spoke-b-2-${AWS::StackName}"
+
+
+# Spoke NLB resources
   SpokeANLB:
     Type: AWS::ElasticLoadBalancingV2::LoadBalancer
     Properties:
@@ -400,6 +534,8 @@ Resources:
       SubnetMappings:
         - SubnetId: !Ref SubnetAWorkload
           PrivateIPv4Address: "10.1.1.10"
+        - SubnetId: !Ref SubnetAWorkload2
+          PrivateIPv4Address: "10.1.2.10"
       Tags:
         - Key: Name
           Value: !Sub "spoke-a-nlb-${AWS::StackName}"
@@ -414,6 +550,7 @@ Resources:
       VpcId: !Ref SpokeVPCA
       Targets:
         - Id: !Ref EC2SubnetA
+        - Id: !Ref EC2SubnetA2
       Tags:
         - Key: Name
           Value: !Sub "spoke-a-nlb-tg-http-${AWS::StackName}"
@@ -438,6 +575,7 @@ Resources:
       VpcId: !Ref SpokeVPCA
       Targets:
         - Id: !Ref EC2SubnetA
+        - Id: !Ref EC2SubnetA2
       Tags:
         - Key: Name
           Value: !Sub "spoke-a-nlb-tg-https-${AWS::StackName}"
@@ -461,6 +599,8 @@ Resources:
       SubnetMappings:
         - SubnetId: !Ref SubnetBWorkload
           PrivateIPv4Address: "10.2.1.10"
+        - SubnetId: !Ref SubnetBWorkload2
+          PrivateIPv4Address: "10.2.2.10"
       Tags:
         - Key: Name
           Value: !Sub "spoke-b-nlb-${AWS::StackName}"
@@ -475,6 +615,7 @@ Resources:
       VpcId: !Ref SpokeVPCB
       Targets:
         - Id: !Ref EC2SubnetB
+        - Id: !Ref EC2SubnetB2
       Tags:
         - Key: Name
           Value: !Sub "spoke-b-nlb-tg-http-${AWS::StackName}"
@@ -499,6 +640,7 @@ Resources:
       VpcId: !Ref SpokeVPCB
       Targets:
         - Id: !Ref EC2SubnetB
+        - Id: !Ref EC2SubnetB2
       Tags:
         - Key: Name
           Value: !Sub "spoke-b-nlb-tg-https-${AWS::StackName}"
@@ -513,8 +655,8 @@ Resources:
         - Type: forward
           TargetGroupArn: !Ref SpokeBNLBTargetGroupHTTPS
 
-# Edge VPC - Central VPC hosting IGW, Network Firewall, ALB, and NAT Gateway
-# All inbound internet traffic enters through this VPC and is inspected by the firewall before reaching spoke workloads
+
+# Edge VPC
   EdgeVPC:
     Type: AWS::EC2::VPC
     Properties:
@@ -526,44 +668,83 @@ Resources:
         - Key: Name
           Value: !Sub "edge-${AWS::StackName}"
 
-  EdgeFirewallSubnet:
+  EdgeFirewallSubnet1:
     Type: AWS::EC2::Subnet
     Properties:
       VpcId:
         Ref: EdgeVPC
       CidrBlock: "100.64.0.16/28"
       AvailabilityZone:
-        Ref: AvailabilityZoneSelection
+        Ref: AvailabilityZoneSelection1
       MapPublicIpOnLaunch: false
       Tags:
         - Key: Name
-          Value: !Sub "edge-firewall-${AWS::StackName}"
+          Value: !Sub "edge-firewall-1-${AWS::StackName}"
 
-  EdgePublicSubnet:
+  EdgeFirewallSubnet2:
+    Type: AWS::EC2::Subnet
+    Properties:
+      VpcId:
+        Ref: EdgeVPC
+      CidrBlock: "100.64.0.32/28"
+      AvailabilityZone:
+        Ref: AvailabilityZoneSelection2
+      MapPublicIpOnLaunch: false
+      Tags:
+        - Key: Name
+          Value: !Sub "edge-firewall-2-${AWS::StackName}"
+
+  EdgePublicSubnet1:
     Type: AWS::EC2::Subnet
     Properties:
       VpcId:
         Ref: EdgeVPC
       CidrBlock: "100.64.1.0/24"
       AvailabilityZone:
-        Ref: AvailabilityZoneSelection
+        Ref: AvailabilityZoneSelection1
       MapPublicIpOnLaunch: true
       Tags:
         - Key: Name
-          Value: !Sub "edge-public-${AWS::StackName}"
+          Value: !Sub "edge-public-1-${AWS::StackName}"
 
-  EdgeTGWSubnet:
+  EdgePublicSubnet2:
+    Type: AWS::EC2::Subnet
+    Properties:
+      VpcId:
+        Ref: EdgeVPC
+      CidrBlock: "100.64.2.0/24"
+      AvailabilityZone:
+        Ref: AvailabilityZoneSelection2
+      MapPublicIpOnLaunch: true
+      Tags:
+        - Key: Name
+          Value: !Sub "edge-public-2-${AWS::StackName}"
+
+  EdgeTGWSubnet1:
     Type: AWS::EC2::Subnet
     Properties:
       VpcId:
         Ref: EdgeVPC
       CidrBlock: "100.64.0.0/28"
       AvailabilityZone:
-        Ref: AvailabilityZoneSelection
+        Ref: AvailabilityZoneSelection1
       MapPublicIpOnLaunch: false
       Tags:
         - Key: Name
-          Value: !Sub "edge-tgw-${AWS::StackName}"
+          Value: !Sub "edge-tgw-1-${AWS::StackName}"
+
+  EdgeTGWSubnet2:
+    Type: AWS::EC2::Subnet
+    Properties:
+      VpcId:
+        Ref: EdgeVPC
+      CidrBlock: "100.64.0.48/28"
+      AvailabilityZone:
+        Ref: AvailabilityZoneSelection2
+      MapPublicIpOnLaunch: false
+      Tags:
+        - Key: Name
+          Value: !Sub "edge-tgw-2-${AWS::StackName}"
 
   EdgeInternetGateway:
     Type: AWS::EC2::InternetGateway
@@ -580,101 +761,147 @@ Resources:
       InternetGatewayId:
         !Ref EdgeInternetGateway
 
-  EdgeNATEIP:
+  EdgeNATEIP1:
     Type: "AWS::EC2::EIP"
     Properties:
       Domain: vpc
 
-  EdgeNATGateway:
+  EdgeNATEIP2:
+    Type: "AWS::EC2::EIP"
+    Properties:
+      Domain: vpc
+
+  EdgeNATGateway1:
     Type: "AWS::EC2::NatGateway"
     Properties:
       AllocationId:
         Fn::GetAtt:
-          - EdgeNATEIP
+          - EdgeNATEIP1
           - AllocationId
       SubnetId:
-        Ref: EdgePublicSubnet
+        Ref: EdgePublicSubnet1
       Tags:
         - Key: Name
-          Value: !Sub "edge-natgw-${AWS::StackName}"
+          Value: !Sub "edge-natgw-1-${AWS::StackName}"
 
-# Edge VPC NLB - Internet-facing NLB receives inspected inbound traffic and forwards to spoke NLBs
-# NLB is used for the single-AZ template because ALBs require a minimum of 2 AZs.
-# The 2AZ template uses an ALB instead, which provides Layer 7 features.
-# Spoke NLBs use static private IPs (via SubnetMappings) so they can be registered as Edge NLB targets directly.
-  EdgeNLB:
+  EdgeNATGateway2:
+    Type: "AWS::EC2::NatGateway"
+    Properties:
+      AllocationId:
+        Fn::GetAtt:
+          - EdgeNATEIP2
+          - AllocationId
+      SubnetId:
+        Ref: EdgePublicSubnet2
+      Tags:
+        - Key: Name
+          Value: !Sub "edge-natgw-2-${AWS::StackName}"
+
+
+# Edge VPC ALB
+  EdgeALBSecurityGroup:
+    Type: AWS::EC2::SecurityGroup
+    Properties:
+      GroupDescription: "Allow HTTP and HTTPS inbound traffic to ALB"
+      GroupName: !Sub "edge-alb-sg-${AWS::StackName}"
+      VpcId: !Ref EdgeVPC
+      SecurityGroupIngress:
+        - IpProtocol: tcp
+          CidrIp: 0.0.0.0/0
+          Description: "Allow HTTP from internet"
+          FromPort: 80
+          ToPort: 80
+        - IpProtocol: tcp
+          CidrIp: 0.0.0.0/0
+          Description: "Allow HTTPS from internet"
+          FromPort: 443
+          ToPort: 443
+
+  EdgeALB:
     Type: AWS::ElasticLoadBalancingV2::LoadBalancer
     DependsOn: AttachEdgeGateway
     Properties:
-      Name: !Sub "edge-nlb-${AWS::StackName}"
+      Name: !Sub "edge-alb-${AWS::StackName}"
       Scheme: internet-facing
-      Type: network
+      Type: application
+      SecurityGroups:
+        - !Ref EdgeALBSecurityGroup
       Subnets:
-        - !Ref EdgePublicSubnet
+        - !Ref EdgePublicSubnet1
+        - !Ref EdgePublicSubnet2
       Tags:
         - Key: Name
-          Value: !Sub "edge-nlb-${AWS::StackName}"
+          Value: !Sub "edge-alb-${AWS::StackName}"
 
-  # IP-type target groups targeting spoke NLB static IPs via TGW
-  # Spoke A NLB: 10.1.1.10, Spoke B NLB: 10.2.1.10 (assigned via SubnetMappings PrivateIPv4Address)
-  # AvailabilityZone: "all" is required for cross-VPC IP targets routed via TGW
-  EdgeNLBTargetGroupHTTP:
+  # IP-type target groups targeting all spoke NLB static IPs via TGW
+  EdgeALBTargetGroupHTTP:
     Type: AWS::ElasticLoadBalancingV2::TargetGroup
     Properties:
       Name: !Sub "e-http-${AWS::StackName}"
       Port: 80
-      Protocol: TCP
+      Protocol: HTTP
       TargetType: ip
       VpcId: !Ref EdgeVPC
       Targets:
         - Id: "10.1.1.10"
           AvailabilityZone: "all"
+        - Id: "10.1.2.10"
+          AvailabilityZone: "all"
         - Id: "10.2.1.10"
+          AvailabilityZone: "all"
+        - Id: "10.2.2.10"
           AvailabilityZone: "all"
       Tags:
         - Key: Name
           Value: !Sub "e-tg-http-${AWS::StackName}"
 
-  EdgeNLBTargetGroupHTTPS:
+  EdgeALBTargetGroupHTTPS:
     Type: AWS::ElasticLoadBalancingV2::TargetGroup
+    Condition: HasALBCertificate
     Properties:
       Name: !Sub "e-htps-${AWS::StackName}"
       Port: 443
-      Protocol: TCP
+      Protocol: HTTPS
       TargetType: ip
       VpcId: !Ref EdgeVPC
       Targets:
         - Id: "10.1.1.10"
           AvailabilityZone: "all"
+        - Id: "10.1.2.10"
+          AvailabilityZone: "all"
         - Id: "10.2.1.10"
+          AvailabilityZone: "all"
+        - Id: "10.2.2.10"
           AvailabilityZone: "all"
       Tags:
         - Key: Name
           Value: !Sub "e-tg-https-${AWS::StackName}"
 
-  EdgeNLBListenerHTTP:
+  EdgeALBListenerHTTP:
     Type: AWS::ElasticLoadBalancingV2::Listener
     Properties:
-      LoadBalancerArn: !Ref EdgeNLB
+      LoadBalancerArn: !Ref EdgeALB
       Port: 80
-      Protocol: TCP
+      Protocol: HTTP
       DefaultActions:
         - Type: forward
-          TargetGroupArn: !Ref EdgeNLBTargetGroupHTTP
+          TargetGroupArn: !Ref EdgeALBTargetGroupHTTP
 
-  EdgeNLBListenerHTTPS:
+  EdgeALBListenerHTTPS:
     Type: AWS::ElasticLoadBalancingV2::Listener
+    Condition: HasALBCertificate
     Properties:
-      LoadBalancerArn: !Ref EdgeNLB
+      LoadBalancerArn: !Ref EdgeALB
       Port: 443
-      Protocol: TCP
+      Protocol: HTTPS
+      Certificates:
+        - CertificateArn: !Ref ALBCertificateArn
       DefaultActions:
         - Type: forward
-          TargetGroupArn: !Ref EdgeNLBTargetGroupHTTPS
+          TargetGroupArn: !Ref EdgeALBTargetGroupHTTPS
 
-# Network Firewall - Inspects all inbound internet traffic before it reaches the NLB and spoke workloads
-# The firewall is deployed in the Firewall Subnet of the Edge VPC
 
+# Network Firewall
   IngressAllowListRuleGroup:
     Type: 'AWS::NetworkFirewall::RuleGroup'
     Properties:
@@ -776,7 +1003,8 @@ Resources:
       FirewallPolicyArn: !Ref IngressFirewallPolicy
       VpcId: !Ref EdgeVPC
       SubnetMappings:
-        - SubnetId: !Ref EdgeFirewallSubnet
+        - SubnetId: !Ref EdgeFirewallSubnet1
+        - SubnetId: !Ref EdgeFirewallSubnet2
       Tags:
         - Key: Name
           Value: !Sub "ingress-firewall-${AWS::StackName}"
@@ -818,8 +1046,8 @@ Resources:
             LogDestination:
               logGroup: !Sub "/${AWS::StackName}/ingress-fw/alert"
 
+
 # Transit Gateway - Connects Edge VPC to Spoke VPCs
-# Spoke traffic routes through TGW to the Edge VPC for inspection, and return traffic flows back via TGW
   CentralTransitGateway:
     Type: "AWS::EC2::TransitGateway"
     Properties:
@@ -839,7 +1067,8 @@ Resources:
     Type: "AWS::EC2::TransitGatewayAttachment"
     Properties:
       SubnetIds:
-        - !Ref EdgeTGWSubnet
+        - !Ref EdgeTGWSubnet1
+        - !Ref EdgeTGWSubnet2
       Options:
         ApplianceModeSupport: enable
       Tags:
@@ -853,6 +1082,7 @@ Resources:
     Properties:
       SubnetIds:
         - !Ref SubnetATGW
+        - !Ref SubnetATGW2
       Tags:
         - Key: Name
           Value: !Sub "spoke-a-attach-${AWS::StackName}"
@@ -864,6 +1094,7 @@ Resources:
     Properties:
       SubnetIds:
         - !Ref SubnetBTGW
+        - !Ref SubnetBTGW2
       Tags:
         - Key: Name
           Value: !Sub "spoke-b-attach-${AWS::StackName}"
@@ -928,17 +1159,9 @@ Resources:
       TransitGatewayAttachmentId: !Ref AttachEdgeVPC
       TransitGatewayRouteTableId: !Ref SpokeRouteTable
 
-# Edge VPC Route Tables - Ingress-specific routing for symmetric firewall inspection
-# Key differences from the egress template:
-#   - Public Subnet routes 0.0.0.0/0 → Firewall Endpoint for symmetric ingress inspection
-#   - Firewall Subnet routes 0.0.0.0/0 → IGW as the exit point for inspected traffic
-#   - TGW Subnet routes 0.0.0.0/0 → NAT Gateway for spoke egress NAT translation
-#   - IGW Ingress Route Table steers inbound traffic through firewall before reaching NLB
 
-  # IGW Ingress Route Table - Associated with the Internet Gateway
-  # Routes inbound traffic destined for the Public Subnet through the firewall endpoint
-  # This is the key construct enabling ingress inspection: traffic arriving at the IGW
-  # for the NLB (in the Public Subnet) is redirected to the firewall first
+# Edge VPC Route Tables
+  # IGW Ingress Route Table
   EdgeIGWIngressRouteTable:
     Type: AWS::EC2::RouteTable
     Properties:
@@ -953,8 +1176,8 @@ Resources:
       RouteTableId: !Ref EdgeIGWIngressRouteTable
       GatewayId: !Ref EdgeInternetGateway
 
-  # Route traffic destined for the Public Subnet CIDR through the firewall endpoint
-  EdgeIGWIngressPublicSubnetRoute:
+  # Route traffic destined for Public Subnet AZ1 CIDR through the AZ1 firewall endpoint
+  EdgeIGWIngressPublicSubnet1Route:
     Type: AWS::EC2::Route
     DependsOn: IngressFirewall
     Properties:
@@ -962,121 +1185,201 @@ Resources:
       VpcEndpointId: !Select [1, !Split [":", !Select [0, !GetAtt IngressFirewall.EndpointIds]]]
       RouteTableId: !Ref EdgeIGWIngressRouteTable
 
-  # Firewall Subnet Route Table
-  # 0.0.0.0/0 → IGW: After the firewall inspects traffic (both ingress return from NLB and
-  # NAT'd spoke egress), the Firewall Subnet forwards it to the IGW for internet delivery.
-  # This is the exit point for ALL inspected outbound traffic.
-  # 10.0.0.0/8 → TGW: Forward inspected inbound traffic to spoke VPCs via Transit Gateway.
-  EdgeFirewallRouteTable:
+  # Route traffic destined for Public Subnet AZ2 CIDR through the AZ2 firewall endpoint
+  EdgeIGWIngressPublicSubnet2Route:
+    Type: AWS::EC2::Route
+    DependsOn: IngressFirewall
+    Properties:
+      DestinationCidrBlock: "100.64.2.0/24"
+      VpcEndpointId: !Select [1, !Split [":", !Select [1, !GetAtt IngressFirewall.EndpointIds]]]
+      RouteTableId: !Ref EdgeIGWIngressRouteTable
+
+  # Firewall Subnet AZ1 Route Table: 0.0.0.0/0 → IGW, 10.0.0.0/8 → TGW
+  EdgeFirewallRouteTable1:
     Type: AWS::EC2::RouteTable
     Properties:
       VpcId: !Ref EdgeVPC
       Tags:
         - Key: Name
-          Value: !Sub "edge-firewall-route-table-${AWS::StackName}"
+          Value: !Sub "edge-firewall-route-table-1-${AWS::StackName}"
 
-  EdgeFirewallRouteTableAssociation:
+  EdgeFirewallRouteTable1Association:
     Type: AWS::EC2::SubnetRouteTableAssociation
-    DependsOn: EdgeFirewallSubnet
+    DependsOn: EdgeFirewallSubnet1
     Properties:
-      RouteTableId: !Ref EdgeFirewallRouteTable
-      SubnetId: !Ref EdgeFirewallSubnet
+      RouteTableId: !Ref EdgeFirewallRouteTable1
+      SubnetId: !Ref EdgeFirewallSubnet1
 
-  EdgeFirewallDefaultRoute:
+  EdgeFirewallDefaultRoute1:
     Type: AWS::EC2::Route
     DependsOn: AttachEdgeGateway
     Properties:
       DestinationCidrBlock: "0.0.0.0/0"
       GatewayId: !Ref EdgeInternetGateway
-      RouteTableId: !Ref EdgeFirewallRouteTable
+      RouteTableId: !Ref EdgeFirewallRouteTable1
 
-  EdgeFirewallTGWRoute:
+  EdgeFirewallTGWRoute1:
     Type: AWS::EC2::Route
     DependsOn: AttachEdgeVPC
     Properties:
       DestinationCidrBlock: "10.0.0.0/8"
       TransitGatewayId: !Ref CentralTransitGateway
-      RouteTableId: !Ref EdgeFirewallRouteTable
+      RouteTableId: !Ref EdgeFirewallRouteTable1
 
-  # Public Subnet Route Table
-  # 0.0.0.0/0 → Firewall Endpoint: CRITICAL for symmetric ingress inspection.
-  # NLB return traffic and NAT Gateway egress traffic both pass through the firewall
-  # before reaching the Firewall Subnet (which then routes to the IGW).
-  # Without this route, NLB return traffic would bypass the firewall and go directly
-  # to the IGW, causing the stateful firewall to see only the inbound direction
-  # and drop return packets (asymmetric routing).
-  # 10.0.0.0/8 → TGW: Edge NLB-to-spoke traffic goes directly to TGW.
-  EdgePublicRouteTable:
+  # Firewall Subnet AZ2 Route Table
+  EdgeFirewallRouteTable2:
     Type: AWS::EC2::RouteTable
     Properties:
       VpcId: !Ref EdgeVPC
       Tags:
         - Key: Name
-          Value: !Sub "edge-public-route-table-${AWS::StackName}"
+          Value: !Sub "edge-firewall-route-table-2-${AWS::StackName}"
 
-  EdgePublicRouteTableAssociation:
+  EdgeFirewallRouteTable2Association:
     Type: AWS::EC2::SubnetRouteTableAssociation
-    DependsOn: EdgePublicSubnet
+    DependsOn: EdgeFirewallSubnet2
     Properties:
-      RouteTableId: !Ref EdgePublicRouteTable
-      SubnetId: !Ref EdgePublicSubnet
+      RouteTableId: !Ref EdgeFirewallRouteTable2
+      SubnetId: !Ref EdgeFirewallSubnet2
 
-  EdgePublicDefaultRoute:
+  EdgeFirewallDefaultRoute2:
+    Type: AWS::EC2::Route
+    DependsOn: AttachEdgeGateway
+    Properties:
+      DestinationCidrBlock: "0.0.0.0/0"
+      GatewayId: !Ref EdgeInternetGateway
+      RouteTableId: !Ref EdgeFirewallRouteTable2
+
+  EdgeFirewallTGWRoute2:
+    Type: AWS::EC2::Route
+    DependsOn: AttachEdgeVPC
+    Properties:
+      DestinationCidrBlock: "10.0.0.0/8"
+      TransitGatewayId: !Ref CentralTransitGateway
+      RouteTableId: !Ref EdgeFirewallRouteTable2
+
+  # Public Subnet AZ1 Route Table: 0.0.0.0/0 → FW Endpoint (symmetric inspection)
+  EdgePublicRouteTable1:
+    Type: AWS::EC2::RouteTable
+    Properties:
+      VpcId: !Ref EdgeVPC
+      Tags:
+        - Key: Name
+          Value: !Sub "edge-public-route-table-1-${AWS::StackName}"
+
+  EdgePublicRouteTable1Association:
+    Type: AWS::EC2::SubnetRouteTableAssociation
+    DependsOn: EdgePublicSubnet1
+    Properties:
+      RouteTableId: !Ref EdgePublicRouteTable1
+      SubnetId: !Ref EdgePublicSubnet1
+
+  EdgePublicDefaultRoute1:
     Type: AWS::EC2::Route
     DependsOn: IngressFirewall
     Properties:
       DestinationCidrBlock: "0.0.0.0/0"
       VpcEndpointId: !Select [1, !Split [":", !Select [0, !GetAtt IngressFirewall.EndpointIds]]]
-      RouteTableId: !Ref EdgePublicRouteTable
+      RouteTableId: !Ref EdgePublicRouteTable1
 
-  EdgePublicTGWRoute:
+  EdgePublicTGWRoute1:
     Type: AWS::EC2::Route
     DependsOn: AttachEdgeVPC
     Properties:
       DestinationCidrBlock: "10.0.0.0/8"
       TransitGatewayId: !Ref CentralTransitGateway
-      RouteTableId: !Ref EdgePublicRouteTable
+      RouteTableId: !Ref EdgePublicRouteTable1
 
-  # TGW Subnet Route Table
-  # 0.0.0.0/0 → NAT Gateway: Spoke egress traffic (e.g., yum install, SSM) enters the
-  # Edge VPC via TGW and is sent to the NAT Gateway for source address translation.
-  # The NAT Gateway's outbound traffic then follows the Public Subnet route table
-  # (0.0.0.0/0 → Firewall Endpoint), ensuring spoke egress is inspected symmetrically.
-  EdgeTGWRouteTable:
+  # Public Subnet AZ2 Route Table
+  EdgePublicRouteTable2:
     Type: AWS::EC2::RouteTable
     Properties:
       VpcId: !Ref EdgeVPC
       Tags:
         - Key: Name
-          Value: !Sub "edge-tgw-route-table-${AWS::StackName}"
+          Value: !Sub "edge-public-route-table-2-${AWS::StackName}"
 
-  EdgeTGWRouteTableAssociation:
+  EdgePublicRouteTable2Association:
     Type: AWS::EC2::SubnetRouteTableAssociation
-    DependsOn: EdgeTGWSubnet
+    DependsOn: EdgePublicSubnet2
     Properties:
-      RouteTableId: !Ref EdgeTGWRouteTable
-      SubnetId: !Ref EdgeTGWSubnet
+      RouteTableId: !Ref EdgePublicRouteTable2
+      SubnetId: !Ref EdgePublicSubnet2
 
-  EdgeTGWDefaultRoute:
+  EdgePublicDefaultRoute2:
     Type: AWS::EC2::Route
-    DependsOn: EdgeNATGateway
+    DependsOn: IngressFirewall
     Properties:
       DestinationCidrBlock: "0.0.0.0/0"
-      NatGatewayId: !Ref EdgeNATGateway
-      RouteTableId: !Ref EdgeTGWRouteTable
+      VpcEndpointId: !Select [1, !Split [":", !Select [1, !GetAtt IngressFirewall.EndpointIds]]]
+      RouteTableId: !Ref EdgePublicRouteTable2
+
+  EdgePublicTGWRoute2:
+    Type: AWS::EC2::Route
+    DependsOn: AttachEdgeVPC
+    Properties:
+      DestinationCidrBlock: "10.0.0.0/8"
+      TransitGatewayId: !Ref CentralTransitGateway
+      RouteTableId: !Ref EdgePublicRouteTable2
+
+  # TGW Subnet AZ1 Route Table: 0.0.0.0/0 → NAT GW (spoke egress)
+  EdgeTGWRouteTable1:
+    Type: AWS::EC2::RouteTable
+    Properties:
+      VpcId: !Ref EdgeVPC
+      Tags:
+        - Key: Name
+          Value: !Sub "edge-tgw-route-table-1-${AWS::StackName}"
+
+  EdgeTGWRouteTable1Association:
+    Type: AWS::EC2::SubnetRouteTableAssociation
+    DependsOn: EdgeTGWSubnet1
+    Properties:
+      RouteTableId: !Ref EdgeTGWRouteTable1
+      SubnetId: !Ref EdgeTGWSubnet1
+
+  EdgeTGWDefaultRoute1:
+    Type: AWS::EC2::Route
+    DependsOn: EdgeNATGateway1
+    Properties:
+      DestinationCidrBlock: "0.0.0.0/0"
+      NatGatewayId: !Ref EdgeNATGateway1
+      RouteTableId: !Ref EdgeTGWRouteTable1
+
+  # TGW Subnet AZ2 Route Table
+  EdgeTGWRouteTable2:
+    Type: AWS::EC2::RouteTable
+    Properties:
+      VpcId: !Ref EdgeVPC
+      Tags:
+        - Key: Name
+          Value: !Sub "edge-tgw-route-table-2-${AWS::StackName}"
+
+  EdgeTGWRouteTable2Association:
+    Type: AWS::EC2::SubnetRouteTableAssociation
+    DependsOn: EdgeTGWSubnet2
+    Properties:
+      RouteTableId: !Ref EdgeTGWRouteTable2
+      SubnetId: !Ref EdgeTGWSubnet2
+
+  EdgeTGWDefaultRoute2:
+    Type: AWS::EC2::Route
+    DependsOn: EdgeNATGateway2
+    Properties:
+      DestinationCidrBlock: "0.0.0.0/0"
+      NatGatewayId: !Ref EdgeNATGateway2
+      RouteTableId: !Ref EdgeTGWRouteTable2
+
 
 # Spoke VPC Route Tables
-# Workload subnets route all traffic to TGW for centralized inspection
-# TGW subnets use default local routes only
-
-  # Spoke A workload subnet route table
+  # Spoke A workload subnet AZ1 route table
   SubnetAWorkloadRouteTable:
     Type: AWS::EC2::RouteTable
     Properties:
       VpcId: !Ref SpokeVPCA
       Tags:
         - Key: Name
-          Value: !Sub "spoke-a-workload-route-table-${AWS::StackName}"
+          Value: !Sub "spoke-a-workload-route-table-1-${AWS::StackName}"
 
   SubnetAWorkloadRouteTableAssociation:
     Type: AWS::EC2::SubnetRouteTableAssociation
@@ -1093,14 +1396,38 @@ Resources:
       TransitGatewayId: !Ref CentralTransitGateway
       RouteTableId: !Ref SubnetAWorkloadRouteTable
 
-  # Spoke B workload subnet route table
+  # Spoke A workload subnet AZ2 route table
+  SubnetAWorkload2RouteTable:
+    Type: AWS::EC2::RouteTable
+    Properties:
+      VpcId: !Ref SpokeVPCA
+      Tags:
+        - Key: Name
+          Value: !Sub "spoke-a-workload-route-table-2-${AWS::StackName}"
+
+  SubnetAWorkload2RouteTableAssociation:
+    Type: AWS::EC2::SubnetRouteTableAssociation
+    DependsOn: SubnetAWorkload2
+    Properties:
+      RouteTableId: !Ref SubnetAWorkload2RouteTable
+      SubnetId: !Ref SubnetAWorkload2
+
+  SubnetAWorkload2DefaultRoute:
+    Type: AWS::EC2::Route
+    DependsOn: AttachSpokeVPCA
+    Properties:
+      DestinationCidrBlock: "0.0.0.0/0"
+      TransitGatewayId: !Ref CentralTransitGateway
+      RouteTableId: !Ref SubnetAWorkload2RouteTable
+
+  # Spoke B workload subnet AZ1 route table
   SubnetBWorkloadRouteTable:
     Type: AWS::EC2::RouteTable
     Properties:
       VpcId: !Ref SpokeVPCB
       Tags:
         - Key: Name
-          Value: !Sub "spoke-b-workload-route-table-${AWS::StackName}"
+          Value: !Sub "spoke-b-workload-route-table-1-${AWS::StackName}"
 
   SubnetBWorkloadRouteTableAssociation:
     Type: AWS::EC2::SubnetRouteTableAssociation
@@ -1117,6 +1444,30 @@ Resources:
       TransitGatewayId: !Ref CentralTransitGateway
       RouteTableId: !Ref SubnetBWorkloadRouteTable
 
+  # Spoke B workload subnet AZ2 route table
+  SubnetBWorkload2RouteTable:
+    Type: AWS::EC2::RouteTable
+    Properties:
+      VpcId: !Ref SpokeVPCB
+      Tags:
+        - Key: Name
+          Value: !Sub "spoke-b-workload-route-table-2-${AWS::StackName}"
+
+  SubnetBWorkload2RouteTableAssociation:
+    Type: AWS::EC2::SubnetRouteTableAssociation
+    DependsOn: SubnetBWorkload2
+    Properties:
+      RouteTableId: !Ref SubnetBWorkload2RouteTable
+      SubnetId: !Ref SubnetBWorkload2
+
+  SubnetBWorkload2DefaultRoute:
+    Type: AWS::EC2::Route
+    DependsOn: AttachSpokeVPCB
+    Properties:
+      DestinationCidrBlock: "0.0.0.0/0"
+      TransitGatewayId: !Ref CentralTransitGateway
+      RouteTableId: !Ref SubnetBWorkload2RouteTable
+
   # Dedicated route tables for TGW subnets (default local routes only)
   SubnetATGWRouteTable:
     Type: AWS::EC2::RouteTable
@@ -1124,7 +1475,7 @@ Resources:
       VpcId: !Ref SpokeVPCA
       Tags:
         - Key: Name
-          Value: !Sub "spoke-a-tgw-route-table-${AWS::StackName}"
+          Value: !Sub "spoke-a-tgw-route-table-1-${AWS::StackName}"
 
   SubnetATGWRouteTableAssociation:
     Type: AWS::EC2::SubnetRouteTableAssociation
@@ -1133,13 +1484,28 @@ Resources:
       RouteTableId: !Ref SubnetATGWRouteTable
       SubnetId: !Ref SubnetATGW
 
+  SubnetATGW2RouteTable:
+    Type: AWS::EC2::RouteTable
+    Properties:
+      VpcId: !Ref SpokeVPCA
+      Tags:
+        - Key: Name
+          Value: !Sub "spoke-a-tgw-route-table-2-${AWS::StackName}"
+
+  SubnetATGW2RouteTableAssociation:
+    Type: AWS::EC2::SubnetRouteTableAssociation
+    DependsOn: SubnetATGW2
+    Properties:
+      RouteTableId: !Ref SubnetATGW2RouteTable
+      SubnetId: !Ref SubnetATGW2
+
   SubnetBTGWRouteTable:
     Type: AWS::EC2::RouteTable
     Properties:
       VpcId: !Ref SpokeVPCB
       Tags:
         - Key: Name
-          Value: !Sub "spoke-b-tgw-route-table-${AWS::StackName}"
+          Value: !Sub "spoke-b-tgw-route-table-1-${AWS::StackName}"
 
   SubnetBTGWRouteTableAssociation:
     Type: AWS::EC2::SubnetRouteTableAssociation
@@ -1148,30 +1514,39 @@ Resources:
       RouteTableId: !Ref SubnetBTGWRouteTable
       SubnetId: !Ref SubnetBTGW
 
-# ============================================================================
-# Traffic Flow Summary:
-#
-# INGRESS PATH:
-#   Internet → IGW → (IGW Ingress RT: Public CIDR → FW Endpoint) → Firewall
-#   → (local route) → NLB in Public Subnet → (Public RT: 10.0.0.0/8 → TGW)
-#   → TGW → Spoke NLB → EC2 httpd
-#
-# INGRESS RETURN (symmetric through firewall):
-#   EC2 → Spoke NLB → TGW → Edge NLB → (Public RT: 0.0.0.0/0 → FW Endpoint)
-#   → Firewall → (Firewall RT: 0.0.0.0/0 → IGW) → Internet
-#
-# SPOKE EGRESS (e.g., yum install, SSM):
-#   Spoke EC2 → TGW → (TGW Subnet RT: 0.0.0.0/0 → NAT GW) → NAT Gateway
-#   → (Public RT: 0.0.0.0/0 → FW Endpoint) → Firewall
-#   → (Firewall RT: 0.0.0.0/0 → IGW) → Internet
-# ============================================================================
+  SubnetBTGW2RouteTable:
+    Type: AWS::EC2::RouteTable
+    Properties:
+      VpcId: !Ref SpokeVPCB
+      Tags:
+        - Key: Name
+          Value: !Sub "spoke-b-tgw-route-table-2-${AWS::StackName}"
+
+  SubnetBTGW2RouteTableAssociation:
+    Type: AWS::EC2::SubnetRouteTableAssociation
+    DependsOn: SubnetBTGW2
+    Properties:
+      RouteTableId: !Ref SubnetBTGW2RouteTable
+      SubnetId: !Ref SubnetBTGW2
 
 Outputs:
-  IngressFirewallEndpoint:
-    Description: Ingress Network Firewall Endpoint ID
+  EdgeALBDNSName:
+    Description: Edge ALB DNS Name
+    Value: !GetAtt EdgeALB.DNSName
+    Export:
+      Name: !Sub "${AWS::StackName}-EdgeALBDNSName"
+
+  IngressFirewallEndpointAZ1:
+    Description: Ingress Network Firewall Endpoint ID (AZ1)
     Value: !Select [1, !Split [":", !Select [0, !GetAtt IngressFirewall.EndpointIds]]]
     Export:
-      Name: !Sub "${AWS::StackName}-IngressFirewallEndpoint"
+      Name: !Sub "${AWS::StackName}-IngressFirewallEndpointAZ1"
+
+  IngressFirewallEndpointAZ2:
+    Description: Ingress Network Firewall Endpoint ID (AZ2)
+    Value: !Select [1, !Split [":", !Select [1, !GetAtt IngressFirewall.EndpointIds]]]
+    Export:
+      Name: !Sub "${AWS::StackName}-IngressFirewallEndpointAZ2"
 
   TransitGatewayId:
     Description: Transit Gateway ID
@@ -1179,62 +1554,8 @@ Outputs:
     Export:
       Name: !Sub "${AWS::StackName}-TransitGatewayId"
 
-  EdgeNLBDNSName:
-    Description: Edge NLB DNS Name
-    Value: !GetAtt EdgeNLB.DNSName
+  EdgeALBSecurityGroupId:
+    Description: Edge ALB Security Group ID
+    Value: !Ref EdgeALBSecurityGroup
     Export:
-      Name: !Sub "${AWS::StackName}-EdgeNLBDNSName"
-
-  EdgeNATGatewayId:
-    Description: Edge NAT Gateway ID
-    Value: !Ref EdgeNATGateway
-    Export:
-      Name: !Sub "${AWS::StackName}-EdgeNATGateway"
-
-  EdgeNATEIPAllocationId:
-    Description: Edge NAT Gateway Elastic IP
-    Value: !Ref EdgeNATEIP
-    Export:
-      Name: !Sub "${AWS::StackName}-EdgeNATEIP"
-
-  SpokeASecurityGroupId:
-    Description: Spoke A Security Group ID
-    Value: !Ref SubnetASecGroup
-    Export:
-      Name: !Sub "${AWS::StackName}-SpokeASecGroup"
-
-  SpokeBSecurityGroupId:
-    Description: Spoke B Security Group ID
-    Value: !Ref SubnetBSecGroup
-    Export:
-      Name: !Sub "${AWS::StackName}-SpokeBSecGroup"
-
-  SpokeANLBDNSName:
-    Description: "Spoke A NLB DNS Name (static IP: 10.1.1.10)"
-    Value: !GetAtt SpokeANLB.DNSName
-    Export:
-      Name: !Sub "${AWS::StackName}-SpokeANLBDNSName"
-
-  SpokeBNLBDNSName:
-    Description: "Spoke B NLB DNS Name (static IP: 10.2.1.10)"
-    Value: !GetAtt SpokeBNLB.DNSName
-    Export:
-      Name: !Sub "${AWS::StackName}-SpokeBNLBDNSName"
-
-  SpokeRouteTableId:
-    Description: Spoke TGW Route Table ID
-    Value: !Ref SpokeRouteTable
-    Export:
-      Name: !Sub "${AWS::StackName}-SpokeRouteTable"
-
-  InspectionRouteTableId:
-    Description: Inspection TGW Route Table ID
-    Value: !Ref InspectionRouteTable
-    Export:
-      Name: !Sub "${AWS::StackName}-InspectionRouteTable"
-
-  EdgeVPCAttachmentId:
-    Description: Edge VPC TGW Attachment ID
-    Value: !Ref AttachEdgeVPC
-    Export:
-      Name: !Sub "${AWS::StackName}-EdgeVPCAttachment"
+      Name: !Sub "${AWS::StackName}-EdgeALBSecGroup"


### PR DESCRIPTION
## Summary

Fixes and improvements to the centralized ingress inspection templates from `feature/centralized-ingress-inspection` (authored by @dnlsouza309).

## Changes

### Both templates
- **Added NLB security group** — `EdgeNLBSecurityGroup` allowing only TCP 80/443 inbound. Without this, the NLB was open on all ports to the internet.
- **Fixed deprecated IAM policy** — `AmazonEC2RoleforSSM` → `AmazonSSMManagedInstanceCore`
- **Fixed hardcoded us-east-1 in UserData** — Now uses `${AWS::Region}` so templates work in any region
- **Fixed typo** — "ICMP acess" → "ICMP access"

### 2-AZ template (rebuilt)
- **Converted ALB to NLB** — Both templates now use the same architecture (NLB). ALB implied web traffic which should use WAF, not NFW. This ensures 1-AZ and 2-AZ are the same architecture at different scales.
- **Updated README** — All ALB references replaced with NLB equivalents

## Testing

Both templates deployed and tested in us-west-2:
- ✅ HTTP ingress working across both spoke VPCs
- ✅ TLS ingress working (tested on 1-AZ with self-signed cert)
- ✅ Multi-AZ load balancing confirmed on 2-AZ
- ✅ NLB security group blocking non-80/443 ports
- ✅ NFW alert logs confirming inspection with real source IPs
- ✅ Spoke egress (httpd install via NAT GW) working